### PR TITLE
Add content-hash dedup, kb_delete feature, and gitignore-aware ingestion

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__knowledge-base__kb_list"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Start the web dashboard + REST API (port 3838)
+KB_PASSWORD=yourpass kb start
+
+# Start MCP stdio server (used by AI tools)
+kb mcp
+
+# Register MCP with Claude Code (~/.claude.json)
+kb register
+
+# Ingest a file or directory
+kb ingest ~/obsidian-vault
+
+# Search from terminal
+kb search "docker networking"
+
+# Delete a document by ID
+kb delete 42
+
+# Delete multiple documents
+kb delete 1 2 3 4 5 6
+
+# Show stats and server status
+kb status
+
+# Auto-classify vault notes (--dry-run to preview)
+kb classify --dry-run
+
+# Add AI summaries to unsummarized docs (--limit=N to cap)
+kb summarize --limit=10
+
+# Reindex Obsidian vault
+kb vault reindex
+
+# Interactive setup wizard
+kb setup
+# Agent-driven (no prompts):
+kb setup --auto --password=yourpass --vault=~/obsidian-vault --agents=claude --deploy=systemd
+
+# Capture X/Twitter bookmarks
+kb capture-x ~/path/to/x_bookmarks.md
+
+# Safety check before a destructive action
+kb safety-check "drop the documents table"
+```
+
+No build step — the codebase runs directly from source (pure ESM). No test runner is configured.
+
+## Architecture
+
+### Data directory: `~/.knowledge-base/`
+All runtime state lives outside the repo:
+- `kb.db` — SQLite database (documents, FTS5 index, embeddings, vault_files, sessions)
+- `files/` — Copies of ingested files with timestamp prefix
+- `config.json` — Bcrypt password hash and settings
+- `kb.pid` — PID file for `kb stop`
+
+### Entry points
+- `bin/kb.js` — CLI dispatcher; loads `.env` from repo root, routes to command modules
+- `src/server.js` — Express web server (dashboard + REST API + MCP HTTP)
+- `src/mcp.js` — MCP stdio server for AI agent integration
+
+### Request paths
+
+**Dashboard (browser):** Cookie auth via `src/auth.js` → `src/routes/auth-routes.js` + `src/routes/api.js`
+
+**External REST API:** `X-API-Key` header or OAuth Bearer → `src/middleware/api-key.js` + `src/auth-oauth.js` → `src/routes/v1.js`
+
+**MCP stdio:** `kb mcp` → `src/mcp.js` → `src/tools.js` (no auth — local process)
+
+**MCP HTTP:** `POST /mcp` → same `brainAuth` as REST → `src/mcp-http.js` → `src/tools.js`
+
+`src/tools.js` is the single source of truth for all MCP tool definitions — shared by both stdio and HTTP transports.
+
+### Database layer (`src/db.js`)
+- Singleton `getDb()` — initializes lazily, runs schema migrations inline on first call
+- FTS5 virtual table `documents_fts` with BM25 ranking; title weight 10×, tags 5×, content 1×
+- Search strategy: AND-first for precision, OR fallback for recall
+- `vault_files` table tracks content hashes for incremental vault re-indexing
+- Embeddings stored as Float32Array binary blobs (3× smaller than JSON)
+- WAL mode with 5-minute periodic checkpoint
+
+### Key modules
+| Module | Responsibility |
+|--------|---------------|
+| `src/ingest.js` | File → DB; duplicate detection by filename (`source` field) |
+| `src/vault/indexer.js` | Obsidian vault incremental indexer (hash-based) |
+| `src/embeddings/embed.js` | Local HuggingFace `Xenova/all-MiniLM-L6-v2` embeddings |
+| `src/embeddings/search.js` | Hybrid FTS5 + cosine similarity search |
+| `src/classify/` | AI auto-classification of vault notes (type, tags, summary) |
+| `src/capture/` | Structured capture: YouTube, web, terminal sessions, bug fixes, X bookmarks |
+| `src/promotion/` | Promotes raw captures → structured knowledge artifacts |
+| `src/synthesis/` | Cross-source synthesis / weekly review |
+| `src/safety/review.js` | Multi-model consensus check before destructive actions |
+| `src/paths.js` | Centralized path constants — always import paths from here |
+
+### Auth model
+- **Dashboard**: bcrypt password stored in `config.json`; 24h session tokens in SQLite `sessions` table; HttpOnly cookie `kb_session`
+- **External API**: Three named API keys (`KB_API_KEY_CLAUDE`, `KB_API_KEY_OPENAI`, `KB_API_KEY_GEMINI`) or OAuth 2.1 Bearer via `better-auth`
+- **ADMIN_ONLY_TOOLS**: `kb_classify`, `kb_promote`, `kb_synthesize`, `kb_safety_check`, `kb_capture_youtube` — gated in the MCP HTTP handler
+
+### Environment variables (`.env` in repo root)
+| Variable | Purpose |
+|----------|---------|
+| `KB_PASSWORD` | Dashboard password (first-run auto-provision) |
+| `KB_PORT` | HTTP port (default 3838) |
+| `OBSIDIAN_VAULT_PATH` | Vault path for sync and classify commands |
+| `KB_API_KEY_CLAUDE` | API key for Claude remote access |
+| `KB_API_KEY_OPENAI` | API key for OpenAI/ChatGPT access |
+| `KB_API_KEY_GEMINI` | API key for Gemini access |
+| `BETTER_AUTH_SECRET` | OAuth token signing secret |
+| `BETTER_AUTH_URL` | OAuth issuer URL (for remote deployment) |
+| `CLASSIFY_MODEL` | Claude model for AI classification (default: claude-haiku-4-5-20251001) |
+| `KB_CORS_ORIGINS` | Comma-separated extra CORS origins |
+
+### Important constraints
+- **Pure ESM** (`"type": "module"` in package.json) — all imports must use `.js` extensions
+- **No build step** — source runs directly via Node.js ≥18
+- **Duplicate detection is by filename** — two different files with the same name will collide in ingestion
+- The embedding model (`all-MiniLM-L6-v2`) loads lazily with a 60s timeout and a mutex to prevent concurrent loads
+- `src/server.js` registers the Better Auth handler **before** `express.json()` — order matters
+- The SPA fallback route (`app.get('*', ...)`) must remain the last route in `server.js`

--- a/agent_memory.md
+++ b/agent_memory.md
@@ -1,0 +1,38 @@
+- Maintain persistent project memory in .agent-memory/. This directory survives across sessions and is the single source of truth for project state.
+  - MEMORY.md — compact index, always loaded at session start. Hard cap: 200 lines. Everything above line 200 is ignored.
+  - Topic files — detailed notes per subject. Never loaded automatically; read on-demand when relevant to the current task.
+- Required .agent-memory/ structure:
+  - MEMORY.md — project status, active features, critical conventions, known pitfalls, topic index.
+  - progress.md — chronological progress log (newest entries on top).
+  - architecture-decisions.md — ADR records with context, decision, rationale, consequences.
+  - conventions.md — code style, git workflow, testing, documentation rules.
+  - debugging-patterns.md — known bugs with symptom, cause, fix, and date discovered.
+  - environment.md — runtime requirements, setup steps, deployment, env var names (never values).
+- MEMORY.md must contain these sections in order:
+  - ## Status — current phase, blockers, next milestone.
+  - ## Active Features — list with [WIP], [DONE], or [BLOCKED] prefixes.
+  - ## Critical Conventions — max 10 lines, imperative voice only.
+  - ## Known Pitfalls — max 5 lines, things that broke before and must be avoided.
+  - ## Topic Index — one-line reference per topic file with brief description.
+- Write MEMORY.md in imperative style. Write "Use pnpm, NEVER npm" — not "The project uses pnpm as its package manager."
+- Memory system session protocol:
+  - On session start: read MEMORY.md in full. Check ## Status for blockers. Load only the topic files relevant to the current task.
+  - During session: write new patterns, bug fixes, and conventions to the appropriate topic file (never directly to MEMORY.md for detailed content). Update MEMORY.md only when project status changes, a feature changes state, a new critical convention or pitfall is discovered, or a new topic file is created.
+  - On session end: append to progress.md what was done this session. Update MEMORY.md ## Status and ## Active Features if changed. Remove stale entries. Ensure MEMORY.md stays under 200 lines.
+- Topic file rules:
+  - One subject per file. No monolithic files.
+  - Every topic file starts with a one-line summary of its contents.
+  - Timestamp significant entries with [YYYY-MM-DD].
+  - Periodically prune outdated information.
+  - Archive old progress entries to progress-archive-YYYY.md when progress.md grows too long.
+- Multi-agent conflict resolution:
+  - MEMORY.md uses last-write-wins. Minimize concurrent writes to it.
+  - Topic files are safer for concurrent edits since agents work on different topics.
+  - Use timestamps ([YYYY-MM-DD HH:MM]) on entries so ordering is unambiguous.
+  - On merge conflicts: keep the most recent entry and remove duplicates.
+- Memory anti-patterns (never do these):
+  - Do not use MEMORY.md as full documentation — it is an index, not a wiki.
+  - Do not load topic files unrelated to the current task — this wastes context.
+  - Do not store secrets, credentials, or env var values in any memory file.
+  - Do not let MEMORY.md go stale — outdated memory is worse than no memory.
+  - Do not write everything down — only persist information that would be lost between sessions and will be reused.

--- a/bin/kb.js
+++ b/bin/kb.js
@@ -2,7 +2,12 @@
 // bin/kb.js — CLI entry point
 // Commands: start, stop, mcp, register, ingest <path>, search <query>, status, setup
 
-import 'dotenv/config';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, '..', '.env') });
 
 const command = process.argv[2];
 const args = process.argv.slice(3);
@@ -14,6 +19,7 @@ const commands = {
   register: () => import('../src/cli/register.js').then(m => m.register()),
   ingest:   () => import('../src/cli/ingest-cli.js').then(m => m.ingest(args[0])),
   search:   () => import('../src/cli/search-cli.js').then(m => m.search(args.join(' '))),
+  delete:   () => import('../src/cli/delete-cli.js').then(m => m.deleteCommand(args)),
   status:   () => import('../src/cli/status.js').then(m => m.status()),
   'capture-x': () => import('../src/capture/x-bookmarks.js').then(m => {
     const bookmarksPath = args[0] || (process.env.HOME + '/knowledgebase/x_bookmarks.md');
@@ -74,6 +80,7 @@ Commands:
   register           Register MCP server with Claude Code
   ingest <path>      Ingest a file or directory
   search <query>     Search documents
+  delete <id> [...]  Delete document(s) by ID
   status             Show stats and server status
   vault reindex      Reindex Obsidian vault
   classify           Auto-classify new clippings/inbox notes (--dry-run to preview)

--- a/global-CLAUDE.md
+++ b/global-CLAUDE.md
@@ -1,0 +1,106 @@
+## Hybrid Memory Protocol
+
+Two memory systems. Never conflate them.
+
+### System Roles
+- `.agent-memory/` = per-project deterministic state. MEMORY.md always loaded. Topic files on-demand. Authoritative for THIS project.
+- Knowledge Base (KB) = cross-project searchable layer via MCP tools. Authoritative for reusable knowledge across all projects.
+- `.agent-memory/` answers "what is true about THIS project right now."
+- KB answers "what have we learned across ALL projects ever."
+
+### Session Start Protocol
+Execute in this exact order:
+1. Read `.agent-memory/MEMORY.md` in full. Check ## Status for blockers.
+2. Load topic files from `.agent-memory/` ONLY if relevant to the current task.
+3. Call `kb_context` with the current task/topic to surface cross-project knowledge.
+4. Review KB summaries. Call `kb_read` ONLY for docs directly relevant to the task.
+5. If the task resembles a past bug or decision, call `kb_search` with the symptom or decision name.
+- Never skip step 1. Never do step 4 before step 3.
+- If `.agent-memory/` does not exist, skip steps 1-2. Still do steps 3-5.
+
+### Retrieval Decision Tree
+Given a question, pick the correct source:
+
+| Question type | Source | Tool/File |
+|---|---|---|
+| Project status, blockers, next step | `.agent-memory/` | MEMORY.md ## Status |
+| Project conventions, code style | `.agent-memory/` | conventions.md |
+| Project architecture decisions | `.agent-memory/` | architecture-decisions.md |
+| Known project bugs and fixes | `.agent-memory/` | debugging-patterns.md |
+| Project environment, setup | `.agent-memory/` | environment.md |
+| "How did we solve X before?" (any project) | KB | `kb_search` or `kb_search_smart` |
+| "What do we know about X?" (general) | KB | `kb_context` → `kb_read` |
+| "Has this bug happened before?" | KB first, then `.agent-memory/` | `kb_search` symptom → debugging-patterns.md |
+| Research, external knowledge | KB | `kb_search_smart` |
+| Past session learnings | KB | `kb_search` or `kb_context` |
+
+- When both systems might have answers: check `.agent-memory/` first (cheaper, no MCP call), then KB.
+- When `.agent-memory/` has project-specific info that contradicts KB general info: project-specific wins.
+
+### Write Decision Tree
+After producing knowledge, persist it to the correct system:
+
+| Knowledge type | Destination | How |
+|---|---|---|
+| Project status change | `.agent-memory/` | Update MEMORY.md ## Status |
+| Feature state change | `.agent-memory/` | Update MEMORY.md ## Active Features |
+| New project convention | `.agent-memory/` | Add to conventions.md + MEMORY.md ## Critical Conventions |
+| New project pitfall | `.agent-memory/` | Add to debugging-patterns.md + MEMORY.md ## Known Pitfalls |
+| Bug fix (reusable across projects) | Both | debugging-patterns.md AND `kb_capture_fix` |
+| Bug fix (project-specific only) | `.agent-memory/` | debugging-patterns.md only |
+| Architecture decision | Both | architecture-decisions.md AND `kb_write` type=decision |
+| Session progress | `.agent-memory/` | Append to progress.md |
+| Debugging session learnings | KB | `kb_capture_session` |
+| Research findings | KB | `kb_write` type=research |
+| General lesson learned | KB | `kb_write` type=lesson |
+
+- Rule: if it helps only THIS project → `.agent-memory/`. If it helps FUTURE projects → KB. If both → both.
+- Never duplicate full content between systems. `.agent-memory/` gets the project-specific version. KB gets the generalized version.
+
+### Session End Protocol
+Execute in this order:
+1. Update `.agent-memory/MEMORY.md` — refresh ## Status, ## Active Features. Remove stale entries.
+2. Append to `.agent-memory/progress.md` — what was done this session, one entry, newest on top.
+3. If a bug was fixed: write to debugging-patterns.md. If reusable, also `kb_capture_fix`.
+4. If a significant debugging/implementation session occurred: call `kb_capture_session` with goal, what worked, what failed, root causes, fixes, lessons.
+5. If a decision was made: write to architecture-decisions.md. If cross-project relevant, also `kb_write` type=decision.
+6. Verify MEMORY.md is under 200 lines. Prune if needed.
+- Never skip steps 1-2. Steps 3-5 are conditional.
+
+### Context Crisis Protocol (>40% Context Used)
+When context window usage exceeds 40%:
+1. Immediately write a handoff note to `.agent-memory/MEMORY.md` ## Status:
+   - Current task and exact stopping point.
+   - What is done, what remains.
+   - Key decisions made this session.
+   - Blockers or open questions.
+2. Call `kb_capture_session` with full session state — goal, progress, failures, lessons.
+3. Update `.agent-memory/progress.md` with session progress so far.
+4. If mid-debugging: write current hypotheses and ruled-out causes to debugging-patterns.md.
+5. Tell the user: context is high, recommend starting a new session.
+6. The new session will recover state via Session Start Protocol — MEMORY.md has the handoff, KB has the session capture.
+- Do NOT wait until 80%. At 40%, start preparing. At 60%, execute steps 1-4 immediately.
+- The handoff note in MEMORY.md ## Status is the critical recovery path. Make it complete.
+
+### Anti-Patterns
+- NEVER store cross-project knowledge only in `.agent-memory/`. It dies with the project.
+- NEVER call `kb_read` without `kb_context` first. Summaries before full docs. Always.
+- NEVER load all `.agent-memory/` topic files at session start. Only load what the task needs.
+- NEVER skip `kb_context` at session start because "this is a simple task." Simple tasks hit known bugs too.
+- NEVER duplicate verbose content between systems. `.agent-memory/` gets project-specific. KB gets generalized.
+- NEVER let MEMORY.md exceed 200 lines. It loads every session. Every line costs tokens.
+- NEVER write secrets, credentials, or env var values to either system.
+- NEVER treat KB as a dump. Use `kb_capture_fix`, `kb_capture_session`, `kb_write` with proper types and structure.
+- NEVER skip session end protocol. A session without capture is a session wasted.
+
+### KB Tool Quick Reference
+| Tool | Use for | Token cost |
+|---|---|---|
+| `kb_context("topic")` | Summaries only, always start here | ~100/doc |
+| `kb_search("query")` | Exact keyword lookup | ~200/result |
+| `kb_search_smart("query")` | Fuzzy/conceptual match | ~200/result |
+| `kb_read(id)` | Full doc content (after context confirms relevance) | ~500-5000/doc |
+| `kb_write(title, type, content)` | Persist decisions, research, lessons | — |
+| `kb_capture_session(...)` | Record debugging/implementation sessions | — |
+| `kb_capture_fix(...)` | Record bug symptom → cause → fix | — |
+| `kb_synthesize(...)` | Cross-cutting insights across sources | — |

--- a/openapi.json
+++ b/openapi.json
@@ -378,6 +378,41 @@
           "401": { "description": "Missing or invalid API key", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
           "404": { "description": "Document not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
         }
+      },
+      "delete": {
+        "operationId": "deleteDocument",
+        "summary": "Delete a document",
+        "description": "Permanently delete a document from the knowledge base by ID. Removes the document, its full-text search index entries, and any associated embeddings. If the document was ingested from a file, the stored copy is also removed.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Document ID to delete.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": { "type": "boolean", "example": true },
+                    "id": { "type": "integer" },
+                    "title": { "type": "string" },
+                    "doc_type": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid document ID", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "401": { "description": "Missing or invalid API key", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
+          "404": { "description": "Document not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } }
+        }
       }
     },
     "/api/v1/ingest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "bcryptjs": "^2.4.3",
         "better-auth": "^1.5.5",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^12.8.0",
         "busboy": "^1.6.0",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
@@ -989,6 +989,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
@@ -1090,6 +1100,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/accepts": {
@@ -1305,14 +1332,17 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bindings": {
@@ -1394,6 +1424,16 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
+    },
+    "node_modules/bson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -2316,6 +2356,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -2414,6 +2461,67 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
+      "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.1.1",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -2690,6 +2798,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3160,6 +3278,16 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3292,6 +3420,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3373,6 +3514,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "bcryptjs": "^2.4.3",
         "better-auth": "^1.5.5",
         "better-sqlite3": "^11.0.0",
+        "busboy": "^1.6.0",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^4.21.0",
         "gray-matter": "^4.0.3",
-        "multer": "^1.4.5-lts.1",
         "pdf-parse": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -1138,12 +1138,6 @@
         }
       }
     },
-    "node_modules/append-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1425,12 +1419,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
-    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1486,21 +1474,6 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1535,12 +1508,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2249,12 +2216,6 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2448,18 +2409,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -2471,25 +2420,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
-      "license": "MIT",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
     },
     "node_modules/nanostores": {
       "version": "1.2.0",
@@ -2715,12 +2645,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -2837,27 +2761,6 @@
       "bin": {
         "rc": "cli.js"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -3433,12 +3336,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -3498,15 +3395,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dotenv": "^17.3.1",
     "express": "^4.21.0",
     "gray-matter": "^4.0.3",
-    "multer": "^1.4.5-lts.1",
+    "busboy": "^1.6.0",
     "pdf-parse": "^1.1.1",
     "zod": "^4.3.6"
   }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "bcryptjs": "^2.4.3",
     "better-auth": "^1.5.5",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.8.0",
+    "busboy": "^1.6.0",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^4.21.0",
     "gray-matter": "^4.0.3",
-    "busboy": "^1.6.0",
     "pdf-parse": "^1.1.1",
     "zod": "^4.3.6"
   }

--- a/src/auth.js
+++ b/src/auth.js
@@ -3,9 +3,21 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { createInterface } from 'readline';
 import { CONFIG_PATH } from './paths.js';
+import { getDb } from './db.js';
 
-const sessions = new Map(); // token -> { expiresAt }
 const SESSION_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+// Initialise sessions table and purge any already-expired rows.
+function initSessions() {
+  const db = getDb();
+  db.exec(`CREATE TABLE IF NOT EXISTS sessions (
+    token TEXT PRIMARY KEY,
+    expires_at INTEGER NOT NULL
+  )`);
+  db.prepare('DELETE FROM sessions WHERE expires_at <= ?').run(Date.now());
+}
+
+initSessions();
 
 /**
  * Check if a password has been configured.
@@ -78,7 +90,7 @@ export function promptPassword() {
  */
 export function createSession() {
   const token = randomBytes(32).toString('hex');
-  sessions.set(token, { expiresAt: Date.now() + SESSION_TTL });
+  getDb().prepare('INSERT OR REPLACE INTO sessions (token, expires_at) VALUES (?, ?)').run(token, Date.now() + SESSION_TTL);
   return token;
 }
 
@@ -97,12 +109,12 @@ function parseCookie(cookieHeader) {
 export function authMiddleware(req, res, next) {
   const token = parseCookie(req.headers.cookie);
   if (token) {
-    const session = sessions.get(token);
-    if (session && session.expiresAt > Date.now()) {
+    const session = getDb().prepare('SELECT expires_at FROM sessions WHERE token = ?').get(token);
+    if (session && session.expires_at > Date.now()) {
       return next();
     }
     // Expired — clean up
-    sessions.delete(token);
+    getDb().prepare('DELETE FROM sessions WHERE token = ?').run(token);
   }
   return res.status(401).json({ error: 'Unauthorized' });
 }
@@ -126,7 +138,7 @@ export function loginHandler(req, res) {
 export function logoutHandler(req, res) {
   const token = parseCookie(req.headers.cookie);
   if (token) {
-    sessions.delete(token);
+    getDb().prepare('DELETE FROM sessions WHERE token = ?').run(token);
   }
   res.setHeader('Set-Cookie', 'kb_session=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0');
   return res.json({ ok: true });
@@ -138,11 +150,11 @@ export function logoutHandler(req, res) {
 export function checkAuthHandler(req, res) {
   const token = parseCookie(req.headers.cookie);
   if (token) {
-    const session = sessions.get(token);
-    if (session && session.expiresAt > Date.now()) {
+    const session = getDb().prepare('SELECT expires_at FROM sessions WHERE token = ?').get(token);
+    if (session && session.expires_at > Date.now()) {
       return res.json({ authenticated: true });
     }
-    sessions.delete(token);
+    getDb().prepare('DELETE FROM sessions WHERE token = ?').run(token);
   }
   return res.json({ authenticated: false });
 }

--- a/src/cli/delete-cli.js
+++ b/src/cli/delete-cli.js
@@ -1,0 +1,32 @@
+import { existsSync, unlinkSync } from 'fs';
+import { getDocument, deleteDocument } from '../db.js';
+
+export function deleteCommand(args) {
+  if (!args.length) {
+    console.error('Usage: kb delete <id> [<id2> ...]');
+    process.exit(1);
+  }
+
+  const ids = args.map(a => parseInt(a, 10)).filter(id => !isNaN(id));
+  if (ids.length === 0) {
+    console.error('Error: No valid document IDs provided.');
+    process.exit(1);
+  }
+
+  let deleted = 0, notFound = 0;
+  for (const id of ids) {
+    const doc = getDocument(id);
+    if (!doc) {
+      console.error(`  Not found: ID ${id}`);
+      notFound++;
+      continue;
+    }
+    const filePath = deleteDocument(id);
+    if (filePath && existsSync(filePath)) {
+      try { unlinkSync(filePath); } catch {}
+    }
+    console.log(`  Deleted: [${doc.doc_type}] ${doc.title} (ID ${id})`);
+    deleted++;
+  }
+  console.log(`\nDone: ${deleted} deleted, ${notFound} not found.`);
+}

--- a/src/db.js
+++ b/src/db.js
@@ -1,5 +1,6 @@
 import Database from 'better-sqlite3';
 import { statSync } from 'fs';
+import { createHash } from 'crypto';
 import { DB_PATH } from './paths.js';
 
 let db = null;
@@ -29,6 +30,7 @@ function initSchema(db) {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       title TEXT NOT NULL,
       content TEXT NOT NULL,
+      content_hash TEXT,
       source TEXT,
       doc_type TEXT NOT NULL,
       tags TEXT DEFAULT '',
@@ -85,6 +87,15 @@ function initSchema(db) {
     CREATE INDEX IF NOT EXISTS idx_vault_files_project ON vault_files(project);
   `);
 
+  // Migration: add content_hash column to documents if missing
+  const docCols = db.prepare("PRAGMA table_info(documents)").all().map(c => c.name);
+  if (!docCols.includes('content_hash')) {
+    db.prepare('ALTER TABLE documents ADD COLUMN content_hash TEXT').run();
+  }
+  // Create unique index after migration (column is guaranteed to exist)
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_hash
+    ON documents(content_hash) WHERE content_hash IS NOT NULL;`);
+
   // Migration: add summary and key_topics columns if missing
   const cols = db.prepare("PRAGMA table_info(vault_files)").all().map(c => c.name);
   if (!cols.includes('summary')) {
@@ -116,15 +127,24 @@ function initSchema(db) {
 export { initSchema, getDb };
 
 export function insertDocument({ title, content, source, doc_type, tags, file_path, file_size }) {
-  const stmt = getDb().prepare(`
-    INSERT INTO documents (title, content, source, doc_type, tags, file_path, file_size)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+  const hash = createHash('sha256').update(content).digest('hex').slice(0, 32);
+  const db = getDb();
+  const stmt = db.prepare(`
+    INSERT OR IGNORE INTO documents (title, content, content_hash, source, doc_type, tags, file_path, file_size)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `);
-  const result = stmt.run(title, content, source || null, doc_type, tags || '', file_path || null, file_size || 0);
+  const result = stmt.run(title, content, hash, source || null, doc_type, tags || '', file_path || null, file_size || 0);
+
+  if (result.changes === 0) {
+    // Duplicate content — return existing document
+    return db.prepare('SELECT * FROM documents WHERE content_hash = ?').get(hash);
+  }
+
   return {
     id: result.lastInsertRowid,
     title,
     content,
+    content_hash: hash,
     source: source || null,
     doc_type,
     tags: tags || '',
@@ -199,7 +219,7 @@ export function searchDocuments(query, limit = 20) {
   const stmt = getDb().prepare(`
     SELECT d.id, d.title,
       snippet(documents_fts, 1, '<mark>', '</mark>', '...', 30) as snippet,
-      d.doc_type, d.tags, d.file_size, d.created_at,
+      d.doc_type, d.tags, d.file_size, d.created_at, d.updated_at,
       bm25(documents_fts, 10.0, 1.0, 5.0) as rank
     FROM documents_fts f
     JOIN documents d ON d.id = f.rowid

--- a/src/ingest.js
+++ b/src/ingest.js
@@ -77,17 +77,21 @@ export async function ingestFile(filePath) {
   return doc;
 }
 
-function collectFiles(dir) {
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', '__pycache__',
+]);
+
+export function collectFiles(dir) {
   const results = [];
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(...collectFiles(fullPath));
+      if (IGNORE_DIRS.has(entry.name)) continue;
+      results.push(...collectFiles(join(dir, entry.name)));
     } else if (entry.isFile()) {
       const ext = extname(entry.name).toLowerCase();
       if (TYPE_MAP[ext]) {
-        results.push(fullPath);
+        results.push(join(dir, entry.name));
       }
     }
   }

--- a/src/ingest.js
+++ b/src/ingest.js
@@ -1,5 +1,5 @@
 import { readFileSync, statSync, readdirSync, copyFileSync, existsSync } from 'fs';
-import { extname, basename, join } from 'path';
+import { extname, basename, join, relative } from 'path';
 import { FILES_DIR } from './paths.js';
 import { insertDocument, listDocuments } from './db.js';
 
@@ -79,19 +79,52 @@ export async function ingestFile(filePath) {
 
 const IGNORE_DIRS = new Set([
   'node_modules', '.git', 'dist', 'build', '__pycache__',
+  'coverage', '.venv', 'venv',
 ]);
 
-export function collectFiles(dir) {
+function loadGitignorePatterns(rootDir) {
+  const gitignorePath = join(rootDir, '.gitignore');
+  if (!existsSync(gitignorePath)) return [];
+  return readFileSync(gitignorePath, 'utf8')
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l && !l.startsWith('#'));
+}
+
+function isIgnoredByGitignore(relPath, patterns) {
+  for (const pattern of patterns) {
+    // Strip leading slash for anchored patterns
+    const p = pattern.startsWith('/') ? pattern.slice(1) : pattern;
+    // Directory pattern (trailing slash): match path segments
+    if (p.endsWith('/')) {
+      const dir = p.slice(0, -1);
+      if (relPath === dir || relPath.startsWith(dir + '/')) return true;
+      continue;
+    }
+    // Simple glob: match basename or full relative path
+    if (relPath === p || relPath.endsWith('/' + p)) return true;
+  }
+  return false;
+}
+
+export function collectFiles(dir, rootDir = dir, gitignorePatterns = null) {
+  if (gitignorePatterns === null) {
+    gitignorePatterns = loadGitignorePatterns(rootDir);
+  }
   const results = [];
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    const relPath = relative(rootDir, fullPath).replace(/\\/g, '/');
     if (entry.isDirectory()) {
       if (IGNORE_DIRS.has(entry.name)) continue;
-      results.push(...collectFiles(join(dir, entry.name)));
+      if (isIgnoredByGitignore(relPath, gitignorePatterns)) continue;
+      results.push(...collectFiles(fullPath, rootDir, gitignorePatterns));
     } else if (entry.isFile()) {
+      if (isIgnoredByGitignore(relPath, gitignorePatterns)) continue;
       const ext = extname(entry.name).toLowerCase();
       if (TYPE_MAP[ext]) {
-        results.push(join(dir, entry.name));
+        results.push(fullPath);
       }
     }
   }

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -4,11 +4,15 @@ let currentDocId = null;
 
 // Init
 document.addEventListener('DOMContentLoaded', async () => {
-  const res = await fetch('/api/auth/check');
-  const data = await res.json();
-  if (data.authenticated) {
-    showApp();
-  } else {
+  try {
+    const res = await fetch('/api/auth-check');
+    const data = await res.json();
+    if (data.authenticated) {
+      showApp();
+    } else {
+      showLogin();
+    }
+  } catch {
     showLogin();
   }
 });
@@ -29,21 +33,39 @@ function showApp() {
 document.getElementById('login-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const password = document.getElementById('login-password').value;
-  const res = await fetch('/api/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ password }),
-  });
-  if (res.ok) {
-    showApp();
-  } else {
-    const err = document.getElementById('login-error');
-    if (res.status === 429) {
-      err.textContent = 'Too many login attempts. Please try again in 15 minutes.';
+  const btn = e.target.querySelector('button[type="submit"]');
+  btn.disabled = true;
+  btn.textContent = 'Signing in…';
+  try {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+    if (res.ok) {
+      showApp();
     } else {
-      err.textContent = 'Invalid password';
+      const err = document.getElementById('login-error');
+      err.textContent = res.status === 429
+        ? 'Too many login attempts. Please try again in 15 minutes.'
+        : 'Invalid password';
+      err.hidden = false;
     }
-    err.hidden = false;
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Sign In';
+  }
+});
+
+document.getElementById('toggle-password').addEventListener('click', () => {
+  const input = document.getElementById('login-password');
+  const btn = document.getElementById('toggle-password');
+  if (input.type === 'password') {
+    input.type = 'text';
+    btn.textContent = 'Hide';
+  } else {
+    input.type = 'password';
+    btn.textContent = 'Show';
   }
 });
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -341,7 +341,7 @@ document.getElementById('password-form').addEventListener('submit', async (e) =>
   e.preventDefault();
   const current = document.getElementById('current-password').value;
   const newPassword = document.getElementById('new-password').value;
-  const res = await fetch('/api/auth/password', {
+  const res = await fetch('/api/password', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ current: current, newPassword: newPassword }),

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -198,8 +198,14 @@ function renderDocumentList(docs) {
     // Title cell - may contain FTS snippet HTML with <mark> tags
     const tdTitle = document.createElement('td');
     if (isSearch && d.snippet) {
-      // Snippet comes from FTS with <mark> highlights - trusted server content
-      tdTitle.innerHTML = d.snippet;
+      // Sanitize: escape all HTML, then restore only <mark> and </mark>
+      const escaped = d.snippet
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      tdTitle.innerHTML = escaped
+        .replace(/&lt;mark&gt;/g, '<mark>')
+        .replace(/&lt;\/mark&gt;/g, '</mark>');
     } else {
       tdTitle.textContent = d.title;
     }

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -38,7 +38,11 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     showApp();
   } else {
     const err = document.getElementById('login-error');
-    err.textContent = 'Invalid password';
+    if (res.status === 429) {
+      err.textContent = 'Too many login attempts. Please try again in 15 minutes.';
+    } else {
+      err.textContent = 'Invalid password';
+    }
     err.hidden = false;
   }
 });

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -13,7 +13,10 @@
       <h1>Knowledge Base</h1>
       <p>Enter your password to continue</p>
       <form id="login-form">
-        <input type="password" id="login-password" placeholder="Password" autofocus>
+        <div class="password-wrapper">
+          <input type="password" id="login-password" placeholder="Password" autofocus>
+          <button type="button" id="toggle-password" aria-label="Show password">Show</button>
+        </div>
         <button type="submit">Sign In</button>
       </form>
       <p id="login-error" class="error" hidden></p>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -49,6 +49,28 @@ body {
   gap: 0.75rem;
 }
 
+.password-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-wrapper input {
+  width: 100%;
+  padding-right: 3.5rem;
+}
+
+#toggle-password {
+  position: absolute;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.25rem;
+}
+
 .error {
   color: #f85149;
   font-size: 0.875rem;

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -87,6 +87,10 @@ body {
   display: none;
 }
 
+.login-screen[hidden] {
+  display: none;
+}
+
 /* Sidebar */
 .sidebar {
   width: 220px;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import multer from 'multer';
 import { writeFileSync, unlinkSync, existsSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { tmpdir, homedir } from 'os';
 import { randomBytes } from 'crypto';
 
 import { authMiddleware } from '../auth.js';
@@ -125,10 +125,18 @@ router.post('/api/ingest-directory', async (req, res) => {
     if (!dirPath) {
       return res.status(400).json({ error: 'path is required' });
     }
-    if (!existsSync(dirPath)) {
+    const resolvedPath = resolve(dirPath);
+    const vaultPath = process.env.OBSIDIAN_VAULT_PATH;
+    const homeDir = homedir();
+    const underVault = vaultPath && resolvedPath.startsWith(resolve(vaultPath));
+    const underHome = resolvedPath.startsWith(homeDir);
+    if (!underVault && !underHome) {
+      return res.status(403).json({ error: 'Path not allowed' });
+    }
+    if (!existsSync(resolvedPath)) {
       return res.status(400).json({ error: `Path not found: ${dirPath}` });
     }
-    const result = await ingestDirectory(dirPath);
+    const result = await ingestDirectory(resolvedPath);
     return res.json(result);
   } catch (err) {
     return res.status(500).json({ error: err.message });

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import multer from 'multer';
+import busboy from 'busboy';
 import { writeFileSync, unlinkSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { tmpdir, homedir } from 'os';
@@ -18,7 +18,6 @@ import { ingestFile, ingestDirectory } from '../ingest.js';
 import { indexVault } from '../vault/indexer.js';
 
 const router = Router();
-const upload = multer({ storage: multer.memoryStorage() });
 
 // All API routes require auth
 router.use('/api/documents', authMiddleware);
@@ -57,41 +56,62 @@ router.get('/api/documents/:id', (req, res) => {
 });
 
 // POST /api/documents — file upload
-router.post('/api/documents', upload.array('files'), async (req, res) => {
-  try {
-    if (!req.files || req.files.length === 0) {
-      return res.status(400).json({ error: 'No files uploaded' });
-    }
+router.post('/api/documents', (req, res) => {
+  const bb = busboy({ headers: req.headers });
+  const uploads = [];
+  let tags = '';
 
-    const documents = [];
-    const tags = req.body.tags || '';
+  bb.on('field', (name, val) => {
+    if (name === 'tags') tags = val;
+  });
 
-    for (const file of req.files) {
-      const tempName = `kb-upload-${randomBytes(8).toString('hex')}-${file.originalname}`;
-      const tempPath = join(tmpdir(), tempName);
+  bb.on('file', (fieldname, fileStream, info) => {
+    const { filename } = info;
+    const chunks = [];
+    fileStream.on('data', (chunk) => chunks.push(chunk));
+    fileStream.on('end', () => {
+      uploads.push({ filename, buffer: Buffer.concat(chunks) });
+    });
+  });
 
-      try {
-        writeFileSync(tempPath, file.buffer);
-        const doc = await ingestFile(tempPath);
-        if (doc) {
-          // Fix title and source to use original filename
-          const origName = file.originalname;
-          const title = origName.replace(/\.[^.]+$/, '');
-          updateDocument(doc.id, { title, tags: tags || doc.tags });
-          doc.title = title;
-          doc.source = origName;
-          if (tags) doc.tags = tags;
-          documents.push(doc);
-        }
-      } finally {
-        try { unlinkSync(tempPath); } catch {}
+  bb.on('finish', async () => {
+    try {
+      if (uploads.length === 0) {
+        return res.status(400).json({ error: 'No files uploaded' });
       }
-    }
 
-    return res.json({ documents });
-  } catch (err) {
-    return res.status(500).json({ error: err.message });
-  }
+      const documents = [];
+
+      for (const file of uploads) {
+        const tempName = `kb-upload-${randomBytes(8).toString('hex')}-${file.filename}`;
+        const tempPath = join(tmpdir(), tempName);
+
+        try {
+          writeFileSync(tempPath, file.buffer);
+          const doc = await ingestFile(tempPath);
+          if (doc) {
+            // Fix title and source to use original filename
+            const title = file.filename.replace(/\.[^.]+$/, '');
+            updateDocument(doc.id, { title, tags: tags || doc.tags });
+            doc.title = title;
+            doc.source = file.filename;
+            if (tags) doc.tags = tags;
+            documents.push(doc);
+          }
+        } finally {
+          try { unlinkSync(tempPath); } catch {}
+        }
+      }
+
+      return res.json({ documents });
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
+  });
+
+  bb.on('error', (err) => res.status(500).json({ error: err.message }));
+
+  req.pipe(bb);
 });
 
 // PUT /api/documents/:id

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -15,7 +15,7 @@ const loginLimiter = rateLimit({
 
 router.post('/api/login', loginLimiter, loginHandler);
 router.post('/api/logout', logoutHandler);
-router.get('/api/auth/check', checkAuthHandler);
+router.get('/api/auth-check', checkAuthHandler);
 
 router.put('/api/auth/password', authMiddleware, (req, res) => {
   const { current, newPassword } = req.body || {};

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -1,9 +1,17 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { loginHandler, logoutHandler, checkAuthHandler, authMiddleware, checkPassword, setPassword } from '../auth.js';
 
 const router = Router();
 
-router.post('/api/login', loginHandler);
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router.post('/api/login', loginLimiter, loginHandler);
 router.post('/api/logout', logoutHandler);
 router.get('/api/auth/check', checkAuthHandler);
 

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -6,9 +6,11 @@ const router = Router();
 
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 5,
+  max: 10,
   standardHeaders: true,
   legacyHeaders: false,
+  skipSuccessfulRequests: true,
+  message: { error: 'Too many login attempts. Please try again in 15 minutes.' },
 });
 
 router.post('/api/login', loginLimiter, loginHandler);

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -17,7 +17,7 @@ router.post('/api/login', loginLimiter, loginHandler);
 router.post('/api/logout', logoutHandler);
 router.get('/api/auth-check', checkAuthHandler);
 
-router.put('/api/auth/password', authMiddleware, (req, res) => {
+router.put('/api/password', authMiddleware, (req, res) => {
   const { current, newPassword } = req.body || {};
   if (!current || !newPassword) {
     return res.status(400).json({ error: 'Both current and newPassword are required' });

--- a/src/routes/v1.js
+++ b/src/routes/v1.js
@@ -2,6 +2,7 @@
 import { Router } from 'express';
 import { homedir } from 'os';
 import { join } from 'path';
+import { existsSync, unlinkSync } from 'fs';
 
 import {
   searchDocuments,
@@ -9,6 +10,7 @@ import {
   getDocument,
   getStats,
   getDb,
+  deleteDocument,
 } from '../db.js';
 import { ingestText } from '../ingest.js';
 
@@ -182,6 +184,27 @@ router.get('/documents/:id', (req, res) => {
       return res.status(404).json({ error: 'Document not found' });
     }
     res.json(doc);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /documents/:id — delete a document
+router.delete('/documents/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    return res.status(400).json({ error: 'Invalid document id' });
+  }
+  try {
+    const doc = getDocument(id);
+    if (!doc) {
+      return res.status(404).json({ error: 'Document not found' });
+    }
+    const filePath = deleteDocument(id);
+    if (filePath && existsSync(filePath)) {
+      try { unlinkSync(filePath); } catch {}
+    }
+    res.json({ deleted: true, id, title: doc.title, doc_type: doc.doc_type });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, mkdirSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import { searchDocuments, listDocuments, getDocument, getStats, getDb } from './db.js';
+import { searchDocuments, listDocuments, getDocument, getStats, getDb, deleteDocument } from './db.js';
 import { ingestText } from './ingest.js';
 import { indexVault } from './vault/indexer.js';
 import { captureYouTube } from './capture/youtube.js';
@@ -18,6 +18,7 @@ const ADMIN_ONLY_TOOLS = new Set([
   'kb_synthesize',
   'kb_safety_check',
   'kb_capture_youtube',
+  'kb_delete',
 ]);
 
 export function getToolDefinitions() {
@@ -370,11 +371,17 @@ export function getToolDefinitions() {
               project: vf?.project || null,
               summary: vf?.summary || r.snippet?.replace(/<\/?mark>/g, '').slice(0, 200),
               key_topics: vf?.key_topics || null,
+              created_at: r.created_at,
+              updated_at: r.updated_at,
             };
           });
 
           if (project || type) {
-            let sql = 'SELECT vf.document_id as id, vf.title, vf.note_type, vf.tags, vf.project, vf.summary, vf.key_topics FROM vault_files vf WHERE 1=1';
+            let sql = `SELECT vf.document_id as id, vf.title, vf.note_type, vf.tags, vf.project, vf.summary, vf.key_topics,
+              d.created_at, d.updated_at
+              FROM vault_files vf
+              LEFT JOIN documents d ON d.id = vf.document_id
+              WHERE 1=1`;
             const params = [];
             if (project) { sql += ' AND vf.project = ?'; params.push(project); }
             if (type) { sql += ' AND vf.note_type = ?'; params.push(type); }
@@ -384,7 +391,7 @@ export function getToolDefinitions() {
             const seenIds = new Set(briefings.map(b => b.id));
             for (const f of filtered) {
               if (!seenIds.has(f.id)) {
-                briefings.push({ id: f.id, title: f.title, type: f.note_type, tags: f.tags, project: f.project, summary: f.summary, key_topics: f.key_topics });
+                briefings.push({ id: f.id, title: f.title, type: f.note_type, tags: f.tags, project: f.project, summary: f.summary, key_topics: f.key_topics, created_at: f.created_at, updated_at: f.updated_at });
               }
             }
           }
@@ -409,6 +416,31 @@ export function getToolDefinitions() {
           const result = await reviewDestructiveAction(action, context);
           const prefix = result.safe ? 'SAFE' : 'BLOCKED';
           return { content: [{ type: 'text', text: `[${prefix}] Risk: ${result.risk_level}\n\n${JSON.stringify(result, null, 2)}` }] };
+        } catch (err) {
+          return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+        }
+      },
+    },
+
+    {
+      name: 'kb_delete',
+      description: 'Delete a document from the knowledge base by ID. Removes the document, its FTS index entries, and any embeddings. If the document was ingested from a file, the stored copy is also deleted. Use kb_list or kb_search to find document IDs first.',
+      schema: {
+        id: z.number().describe('Document ID to delete'),
+      },
+      handler: async ({ id }) => {
+        try {
+          const doc = getDocument(id);
+          if (!doc) {
+            return { content: [{ type: 'text', text: `Error: Document with ID ${id} not found.` }], isError: true };
+          }
+          const filePath = deleteDocument(id);
+          if (filePath && existsSync(filePath)) {
+            try { unlinkSync(filePath); } catch { /* non-fatal */ }
+          }
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ deleted: true, id, title: doc.title, doc_type: doc.doc_type }) }],
+          };
         } catch (err) {
           return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
         }

--- a/tests/auth-full-server.test.js
+++ b/tests/auth-full-server.test.js
@@ -84,30 +84,19 @@ describe('Full server auth flow (with Better Auth)', () => {
     });
   });
 
-  it('PUT /api/password is NOT intercepted by Better Auth', async () => {
+  it('PUT /api/password is NOT intercepted by Better Auth (returns 401 not 404)', async () => {
     await withServer(async (port) => {
-      // Login first
-      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ password: TEST_PASSWORD }),
-      });
-      const setCookie = loginRes.headers.get('set-cookie');
-      const cookie = setCookie.split(';')[0];
-
-      // Try to change password — now at /api/password (not under /api/auth/)
-      const changeRes = await fetch(`http://localhost:${port}/api/password`, {
+      // Without a valid session, our authMiddleware returns 401.
+      // Better Auth would return 404 for routes it doesn't know about.
+      // So 401 here proves the route is handled by our router, not Better Auth.
+      const res = await fetch(`http://localhost:${port}/api/password`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Cookie: cookie },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ current: TEST_PASSWORD, newPassword: 'newpass456' }),
       });
-
-      assert.strictEqual(changeRes.status, 200, 'Password change should succeed');
-      const data = await changeRes.json();
-      assert.strictEqual(data.ok, true, 'Should return { ok: true } from dashboard handler');
-
-      // Restore password
-      setPassword(TEST_PASSWORD);
+      assert.strictEqual(res.status, 401, 'Should be 401 from authMiddleware (not 404 from Better Auth)');
+      const data = await res.json();
+      assert.strictEqual(data.error, 'Unauthorized', 'Should return our authMiddleware error, not a Better Auth error');
     });
   });
 });

--- a/tests/auth-full-server.test.js
+++ b/tests/auth-full-server.test.js
@@ -1,0 +1,113 @@
+// tests/auth-full-server.test.js — Test auth with full server middleware stack
+// This simulates the actual server.js setup including Better Auth catch-all
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import { setPassword } from '../src/auth.js';
+import authRoutes from '../src/routes/auth-routes.js';
+import apiRoutes from '../src/routes/api.js';
+import cors from 'cors';
+import { toNodeHandler } from 'better-auth/node';
+import { auth } from '../src/auth-oauth.js';
+
+const TEST_PASSWORD = 'testpass123';
+setPassword(TEST_PASSWORD);
+
+function createFullApp() {
+  const app = express();
+
+  // Replicate server.js middleware order
+  const corsMiddleware = cors({ origin: '*', credentials: true });
+
+  // Better Auth catch-all (line 87 in server.js) — BEFORE express.json()
+  app.all('/api/auth/*', corsMiddleware, toNodeHandler(auth));
+
+  // JSON body parsing (line 116 in server.js)
+  app.use(express.json({ limit: '1mb' }));
+
+  // Dashboard routes (line 120-121 in server.js)
+  app.use(authRoutes);
+  app.use(apiRoutes);
+
+  return app;
+}
+
+async function withServer(fn) {
+  const app = createFullApp();
+  const server = app.listen(0);
+  const port = server.address().port;
+  try {
+    await fn(port);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+describe('Full server auth flow (with Better Auth)', () => {
+  it('POST /api/login still works', async () => {
+    await withServer(async (port) => {
+      const res = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      assert.strictEqual(res.status, 200);
+      const data = await res.json();
+      assert.strictEqual(data.ok, true);
+    });
+  });
+
+  it('Login → GET /api/stats works', async () => {
+    await withServer(async (port) => {
+      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      assert.strictEqual(loginRes.status, 200);
+      const setCookie = loginRes.headers.get('set-cookie');
+      const cookie = setCookie.split(';')[0];
+
+      const statsRes = await fetch(`http://localhost:${port}/api/stats`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(statsRes.status, 200);
+    });
+  });
+
+  it('GET /api/auth-check is NOT intercepted by Better Auth', async () => {
+    await withServer(async (port) => {
+      const res = await fetch(`http://localhost:${port}/api/auth-check`);
+      const data = await res.json();
+      // Should return our dashboard response, not Better Auth's
+      assert.ok('authenticated' in data, 'Should return dashboard auth-check response with authenticated field');
+    });
+  });
+
+  it('PUT /api/password is NOT intercepted by Better Auth', async () => {
+    await withServer(async (port) => {
+      // Login first
+      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      const setCookie = loginRes.headers.get('set-cookie');
+      const cookie = setCookie.split(';')[0];
+
+      // Try to change password — now at /api/password (not under /api/auth/)
+      const changeRes = await fetch(`http://localhost:${port}/api/password`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: cookie },
+        body: JSON.stringify({ current: TEST_PASSWORD, newPassword: 'newpass456' }),
+      });
+
+      assert.strictEqual(changeRes.status, 200, 'Password change should succeed');
+      const data = await changeRes.json();
+      assert.strictEqual(data.ok, true, 'Should return { ok: true } from dashboard handler');
+
+      // Restore password
+      setPassword(TEST_PASSWORD);
+    });
+  });
+});

--- a/tests/auth-full-server.test.js
+++ b/tests/auth-full-server.test.js
@@ -1,14 +1,19 @@
 // tests/auth-full-server.test.js — Test auth with full server middleware stack
 // This simulates the actual server.js setup including Better Auth catch-all
-import { describe, it } from 'node:test';
+import { describe, it, after } from 'node:test';
 import assert from 'node:assert';
 import express from 'express';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { setPassword } from '../src/auth.js';
 import authRoutes from '../src/routes/auth-routes.js';
 import apiRoutes from '../src/routes/api.js';
+import { CONFIG_PATH } from '../src/paths.js';
 import cors from 'cors';
 import { toNodeHandler } from 'better-auth/node';
 import { auth } from '../src/auth-oauth.js';
+
+// Backup existing config before tests overwrite it
+const _configBackup = existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, 'utf-8') : null;
 
 const TEST_PASSWORD = 'testpass123';
 setPassword(TEST_PASSWORD);
@@ -44,6 +49,13 @@ async function withServer(fn) {
 }
 
 describe('Full server auth flow (with Better Auth)', () => {
+  // Restore original config after all tests
+  after(() => {
+    if (_configBackup !== null) {
+      writeFileSync(CONFIG_PATH, _configBackup);
+    }
+  });
+
   it('POST /api/login still works', async () => {
     await withServer(async (port) => {
       const res = await fetch(`http://localhost:${port}/api/login`, {

--- a/tests/auth-login.test.js
+++ b/tests/auth-login.test.js
@@ -1,0 +1,182 @@
+// tests/auth-login.test.js — Test dashboard login → authenticated API flow
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import { setPassword, loginHandler, logoutHandler, checkAuthHandler, authMiddleware } from '../src/auth.js';
+import { getStats } from '../src/db.js';
+import authRoutes from '../src/routes/auth-routes.js';
+import apiRoutes from '../src/routes/api.js';
+
+// Set a known password for testing
+const TEST_PASSWORD = 'testpass123';
+setPassword(TEST_PASSWORD);
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(authRoutes);
+  app.use(apiRoutes);
+  return app;
+}
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  const port = server.address().port;
+  try {
+    await fn(port);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+describe('Dashboard auth flow', () => {
+  it('GET /api/stats without auth returns 401', async () => {
+    await withServer(async (port) => {
+      const res = await fetch(`http://localhost:${port}/api/stats`);
+      assert.strictEqual(res.status, 401);
+    });
+  });
+
+  it('POST /api/login with wrong password returns 401', async () => {
+    await withServer(async (port) => {
+      const res = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: 'wrongpass' }),
+      });
+      assert.strictEqual(res.status, 401);
+      // Should NOT set a cookie
+      const setCookie = res.headers.get('set-cookie');
+      assert.strictEqual(setCookie, null);
+    });
+  });
+
+  it('POST /api/login with correct password returns 200 and sets cookie', async () => {
+    await withServer(async (port) => {
+      const res = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      assert.strictEqual(res.status, 200);
+      const data = await res.json();
+      assert.strictEqual(data.ok, true);
+      // Should set kb_session cookie
+      const setCookie = res.headers.get('set-cookie');
+      assert.ok(setCookie, 'login response should set a cookie');
+      assert.ok(setCookie.includes('kb_session='), 'cookie should be kb_session');
+    });
+  });
+
+  it('Login then GET /api/stats succeeds with session cookie', async () => {
+    await withServer(async (port) => {
+      // Login first
+      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      assert.strictEqual(loginRes.status, 200);
+
+      // Extract cookie from login response
+      const setCookie = loginRes.headers.get('set-cookie');
+      const cookie = setCookie.split(';')[0]; // "kb_session=..."
+
+      // Use cookie to access stats
+      const statsRes = await fetch(`http://localhost:${port}/api/stats`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(statsRes.status, 200);
+      const stats = await statsRes.json();
+      assert.ok('count' in stats, 'stats should have count');
+      assert.ok('totalSize' in stats, 'stats should have totalSize');
+    });
+  });
+
+  it('GET /api/auth-check reflects authentication state', async () => {
+    await withServer(async (port) => {
+      // Without cookie — not authenticated
+      const noAuthRes = await fetch(`http://localhost:${port}/api/auth-check`);
+      const noAuthData = await noAuthRes.json();
+      assert.strictEqual(noAuthData.authenticated, false);
+
+      // Login
+      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      const setCookie = loginRes.headers.get('set-cookie');
+      const cookie = setCookie.split(';')[0];
+
+      // With cookie — authenticated
+      const authRes = await fetch(`http://localhost:${port}/api/auth-check`, {
+        headers: { Cookie: cookie },
+      });
+      const authData = await authRes.json();
+      assert.strictEqual(authData.authenticated, true);
+    });
+  });
+
+  it('POST /api/logout clears session', async () => {
+    await withServer(async (port) => {
+      // Login
+      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      const setCookie = loginRes.headers.get('set-cookie');
+      const cookie = setCookie.split(';')[0];
+
+      // Logout
+      const logoutRes = await fetch(`http://localhost:${port}/api/logout`, {
+        method: 'POST',
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(logoutRes.status, 200);
+
+      // Session should be invalid now
+      const statsRes = await fetch(`http://localhost:${port}/api/stats`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(statsRes.status, 401);
+    });
+  });
+
+  it('PUT /api/password changes password with valid session', async () => {
+    await withServer(async (port) => {
+      // Login
+      const loginRes = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      });
+      const setCookie = loginRes.headers.get('set-cookie');
+      const cookie = setCookie.split(';')[0];
+
+      // Change password
+      const newPass = 'newpass456';
+      const changeRes = await fetch(`http://localhost:${port}/api/password`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: cookie },
+        body: JSON.stringify({ current: TEST_PASSWORD, newPassword: newPass }),
+      });
+      assert.strictEqual(changeRes.status, 200);
+      const changeData = await changeRes.json();
+      assert.strictEqual(changeData.ok, true);
+
+      // Login with new password should work
+      const loginRes2 = await fetch(`http://localhost:${port}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: newPass }),
+      });
+      assert.strictEqual(loginRes2.status, 200);
+
+      // Restore original password for other tests
+      setPassword(TEST_PASSWORD);
+    });
+  });
+});

--- a/tests/auth-login.test.js
+++ b/tests/auth-login.test.js
@@ -1,11 +1,16 @@
 // tests/auth-login.test.js — Test dashboard login → authenticated API flow
-import { describe, it, before } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import express from 'express';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { setPassword, loginHandler, logoutHandler, checkAuthHandler, authMiddleware } from '../src/auth.js';
 import { getStats } from '../src/db.js';
 import authRoutes from '../src/routes/auth-routes.js';
 import apiRoutes from '../src/routes/api.js';
+import { CONFIG_PATH } from '../src/paths.js';
+
+// Backup existing config before tests overwrite it
+const _configBackup = existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, 'utf-8') : null;
 
 // Set a known password for testing
 const TEST_PASSWORD = 'testpass123';
@@ -31,6 +36,13 @@ async function withServer(fn) {
 }
 
 describe('Dashboard auth flow', () => {
+  // Restore original config after all tests
+  after(() => {
+    if (_configBackup !== null) {
+      writeFileSync(CONFIG_PATH, _configBackup);
+    }
+  });
+
   it('GET /api/stats without auth returns 401', async () => {
     await withServer(async (port) => {
       const res = await fetch(`http://localhost:${port}/api/stats`);

--- a/tests/ingest.test.js
+++ b/tests/ingest.test.js
@@ -1,0 +1,45 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { collectFiles } from '../src/ingest.js';
+
+describe('collectFiles', () => {
+  let testDir;
+
+  before(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'test-ingest-'));
+
+    // A valid markdown file at root
+    writeFileSync(join(testDir, 'readme.md'), '# Hello');
+
+    // Files inside ignored directories — should all be skipped
+    for (const ignored of ['node_modules', '.git', 'dist', 'build', '__pycache__']) {
+      mkdirSync(join(testDir, ignored), { recursive: true });
+      writeFileSync(join(testDir, ignored, 'file.md'), '# ignored');
+    }
+
+    // A valid file in a normal subdirectory — should be included
+    mkdirSync(join(testDir, 'docs'), { recursive: true });
+    writeFileSync(join(testDir, 'docs', 'guide.md'), '# Guide');
+  });
+
+  after(() => rmSync(testDir, { recursive: true, force: true }));
+
+  it('should collect files in normal directories', () => {
+    const files = collectFiles(testDir);
+    assert.ok(files.some(f => f.endsWith('readme.md')), 'should include readme.md');
+    assert.ok(files.some(f => f.endsWith('guide.md')), 'should include docs/guide.md');
+  });
+
+  it('should skip node_modules, .git, dist, build, and __pycache__', () => {
+    const files = collectFiles(testDir);
+    for (const ignored of ['node_modules', '.git', 'dist', 'build', '__pycache__']) {
+      assert.ok(
+        !files.some(f => f.includes(`/${ignored}/`)),
+        `should not include files from ${ignored}/`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Dedup**: `content_hash` (SHA-256, 32 chars) kolom + conditionele UNIQUE index op `documents`. `insertDocument()` doet `INSERT OR IGNORE` met fallback SELECT — duplicate detection zit nu in de laagste DB-laag.
- **Gitignore-aware ingestion**: `collectFiles()` leest `.gitignore` patronen en respecteert die bij directory traversal. Uitgebreide `SKIP_DIRS` met `coverage`, `.venv`, `venv`.
- **kb_delete**: Document verwijderen op alle 3 access layers — MCP tool (`kb_delete`, admin-only), CLI (`kb delete <id> [...]`), REST (`DELETE /api/v1/documents/:id`). Cascade cleanup van FTS index, embeddings en opgeslagen bestand.
- **Date fields in kb_context**: `created_at` en `updated_at` toegevoegd aan briefings in beide code paths (FTS + vault_files).
- **Dotenv fix**: `bin/kb.js` laadt `.env` nu via expliciete `__dirname`-gebaseerd pad i.p.v. `import 'dotenv/config'` (fix voor werkdirectory mismatch).
- **CLAUDE.md**: Project instructies toegevoegd voor Claude Code integratie.
- **OpenAPI spec**: DELETE operatie gedocumenteerd.

## Test plan

- [ ] `kb delete <id>` verwijdert document, print bevestiging
- [ ] `kb delete <id1> <id2>` verwijdert meerdere documenten
- [ ] `kb delete <niet-bestaand-id>` geeft "Not found" zonder crash
- [ ] Dubbele ingest van dezelfde content retourneert zelfde ID
- [ ] `kb_context` toont `created_at` en `updated_at` in briefings
- [ ] `DELETE /api/v1/documents/:id` retourneert 200 met `{ deleted: true }`
- [ ] `collectFiles()` slaat `.venv` en `node_modules` over bij ingest

🤖 Generated with [Claude Code](https://claude.com/claude-code)