### PR TITLE
feat: add local cross-agent message bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,21 +218,22 @@ kb setup --auto --password=yourpass --vault=~/obsidian-vault --agents=claude,cod
 
 ```bash
 KB_PASSWORD=yourpassword kb start    # Start server on port 3838
-kb register                          # Register MCP with Claude Code
+kb register                          # Register MCP with Claude, Codex, and Gemini
+kb register --agents=claude,codex    # Register only a subset
 kb ingest ~/obsidian-vault           # Ingest your knowledge
 kb search "docker networking"        # Search from terminal
 kb status                            # Check stats
 ```
 
-### Connect to Claude Code
+### Connect to Local Agents
 
-After `kb register`, Claude Code automatically has access to all KB tools. Test it:
+After `kb register`, Claude Code, Codex CLI, and Gemini CLI automatically point at `kb mcp`. Restart the sessions you want to update, then test it:
 
 ```
 > Search the knowledge base for recent bug fixes
 ```
 
-Claude will use `kb_search` and return results from your accumulated knowledge.
+Your agent will use `kb_search` and return results from your accumulated knowledge.
 
 ---
 
@@ -262,7 +263,9 @@ First 500 early adopters get Pro at $12/mo forever (normally $25): [memstalker.c
 
 ## MCP Tools
 
-All 16 tools available via MCP (stdio and HTTP):
+### Core tools (stdio + HTTP)
+
+All 16 core tools are available via both stdio and HTTP:
 
 | Tool | Description |
 |------|-------------|
@@ -282,6 +285,28 @@ All 16 tools available via MCP (stdio and HTTP):
 | `kb_capture_youtube` | Capture a YouTube transcript with metadata |
 | `kb_vault_status` | Show vault indexing stats by type and project |
 | `kb_safety_check` | Review a destructive action against KB history |
+
+### Local-only bus tools (stdio only)
+
+The stdio MCP server also exposes a lightweight append-only message bus for cross-model coordination:
+
+| Tool | Description |
+|------|-------------|
+| `bus_send` | Send a markdown message to a local channel |
+| `bus_inbox` | Read messages newer than a cursor |
+| `bus_wait` | Long-poll until a new message arrives or timeout elapses |
+
+Resource template: `bus://{channel}`
+
+Shell shims:
+
+```bash
+bus-send ticket:PF-1884 "report ready" --sender codex --kind result
+bus-inbox ticket:PF-1884 --since 0
+bus-wait ticket:PF-1884 --since 12 --timeout-ms 30000
+```
+
+See [docs/message-bus.md](docs/message-bus.md) for channel conventions and cross-model usage.
 
 ---
 
@@ -416,7 +441,7 @@ Use kb_capture_fix to record:
 ### Claude Code (MCP -- Native)
 
 ```bash
-kb register    # Writes to ~/.claude.json automatically
+kb register    # Writes to ~/.claude.json, ~/.codex/mcp.json, ~/.gemini/mcp.json
 ```
 
 All 16 MCP tools become available in Claude Code immediately.

--- a/bin/bus-inbox.js
+++ b/bin/bus-inbox.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { runBusInboxCli } from '../src/bus/cli.js';
+
+runBusInboxCli(process.argv.slice(2)).catch(err => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/bin/bus-send.js
+++ b/bin/bus-send.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { runBusSendCli } from '../src/bus/cli.js';
+
+runBusSendCli(process.argv.slice(2)).catch(err => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/bin/bus-wait.js
+++ b/bin/bus-wait.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { runBusWaitCli } from '../src/bus/cli.js';
+
+runBusWaitCli(process.argv.slice(2)).catch(err => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/bin/kb.js
+++ b/bin/kb.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // bin/kb.js — CLI entry point
-// Commands: start, stop, mcp, register, ingest <path>, search <query>, status, setup
+// Commands: start, stop, mcp, register, ingest <path>, search <query>, status, setup, bus-send, bus-inbox, bus-wait
 
 import '../src/paths.js'; // loads .env from ~/.knowledge-base/.env
 
@@ -11,11 +11,14 @@ const commands = {
   start:    () => import('../src/server.js').then(m => m.start()),
   stop:     () => import('../src/cli/stop.js').then(m => m.stop()),
   mcp:      () => import('../src/mcp.js').then(m => m.start()),
-  register: () => import('../src/cli/register.js').then(m => m.register()),
+  register: () => import('../src/cli/register.js').then(m => m.register(args)),
   ingest:   () => import('../src/cli/ingest-cli.js').then(m => m.ingest(args[0])),
   search:   () => import('../src/cli/search-cli.js').then(m => m.search(args.join(' '))),
   'token-compare': () => import('../src/cli/token-compare.js').then(m => m.tokenCompare(args)),
   status:   () => import('../src/cli/status.js').then(m => m.status()),
+  'bus-send': () => import('../src/bus/cli.js').then(m => m.runBusSendCli(args)),
+  'bus-inbox': () => import('../src/bus/cli.js').then(m => m.runBusInboxCli(args)),
+  'bus-wait': () => import('../src/bus/cli.js').then(m => m.runBusWaitCli(args)),
   'capture-x': () => import('../src/capture/x-bookmarks.js').then(m => {
     const bookmarksPath = args[0] || (process.env.HOME + '/knowledgebase/x_bookmarks.md');
     const vaultPath = process.env.OBSIDIAN_VAULT_PATH;
@@ -72,11 +75,14 @@ Commands:
   start              Start the dashboard server (default :3838)
   stop               Stop the running server
   mcp                Start MCP stdio server (used by AI tools)
-  register           Register MCP server with Claude Code
+  register           Register MCP server with Claude/Codex/Gemini (--agents=claude,codex)
   ingest <path>      Ingest a file or directory
   search <query>     Search documents
   token-compare      Compare raw-doc vs KB-summary token cost
   status             Show stats and server status
+  bus-send           Send a local message bus message
+  bus-inbox          Read messages from a local message bus channel
+  bus-wait           Long-poll a local message bus channel
   vault reindex      Reindex Obsidian vault
   classify           Auto-classify new clippings/inbox notes (--dry-run to preview)
   summarize          Add AI summaries to docs without them (--dry-run, --limit=N)

--- a/docs/SKILL-VS-MCP.md
+++ b/docs/SKILL-VS-MCP.md
@@ -8,7 +8,7 @@ This project ships two ways to use it. They solve different problems and work be
 
 **How it works:** Your agent decides when to call a tool. It sends a request ("search for X"), gets back results, and uses them. No tokens are spent until a tool is called.
 
-**Install:** `kb register` adds it to Claude Code. For other agents, point your MCP config at `kb mcp`.
+**Install:** `kb register` adds it to Claude Code, Codex, and Gemini. You can limit targets with `kb register --agents=claude,codex`.
 
 **Token cost:** ~500 tokens for tool definitions (always in context) + whatever results come back per call.
 
@@ -57,7 +57,7 @@ git clone https://github.com/willynikes2/knowledge-base-server.git
 cd knowledge-base-server
 npm install && npm link
 kb setup
-kb register   # Registers MCP tools with Claude Code
+kb register   # Registers MCP tools with Claude Code, Codex, and Gemini
 ```
 
 Your agent now has all 16 KB tools.
@@ -86,7 +86,7 @@ The skill is just a markdown file. Include its content in your agent's system pr
 
 | Platform | MCP Server | Skill |
 |----------|-----------|-------|
-| Claude Code | `kb register` | Copy to skills dir |
+| Claude Code / Codex / Gemini | `kb register` | Copy to skills dir |
 | Claude Web | Connect via remote MCP | Not applicable (use custom instructions) |
 | ChatGPT | Import OpenAPI spec | Add to Custom GPT instructions |
 | Codex CLI | MCP config in `.codex/mcp.json` | Add to `instructions.md` |

--- a/docs/message-bus.md
+++ b/docs/message-bus.md
@@ -1,0 +1,68 @@
+# Local message bus
+
+The knowledge-base MCP server now includes a **local-only message bus** for agent-to-agent coordination across Claude Code, Codex, Gemini, and shell scripts.
+
+## What ships in V1
+
+- MCP tools: `bus_send`, `bus_inbox`, `bus_wait`
+- MCP resource template: `bus://{channel}`
+- CLI shims: `bus-send`, `bus-inbox`, `bus-wait`
+- Shared append-only SQLite storage at `~/.claude/bus/bus.db`
+
+Because this is an extension of `kb mcp`, you do **not** need a second MCP server if KB is already registered. Any client already pointed at `kb mcp` gets the bus tools automatically on next restart.
+
+Run `kb register` to update local Claude/Codex/Gemini MCP configs in one shot, then restart the sessions that should gain `bus_send`.
+
+## Channel naming
+
+Use free-form channel IDs with stable prefixes:
+
+- `ticket:PF-1884`
+- `session:3d74f5b1`
+- `swarm:frontend-refactor`
+- `deploy:eva-sandbox`
+
+## Recommended flow
+
+### From an external script / Codex shell
+
+```bash
+bus-send ticket:PF-1884 "Implementation finished. Tests passed." \
+  --sender codex \
+  --kind result \
+  --metadata '{"model":"gpt-5.4","branch":"uttam/pf-1884-message-bus"}'
+```
+
+### From an MCP client
+
+- Send: `bus_send(channel, sender, message, kind?, metadata_json?)`
+- Poll: `bus_inbox(channel, since?)`
+- Long-poll: `bus_wait(channel, since?, timeout_ms?)`
+
+Use the returned `next_since` as the next cursor.
+
+## Resources
+
+`bus://ticket:PF-1884` returns the latest messages for that channel as JSON.
+
+If your MCP host supports resource subscriptions, you can subscribe to that URI. In practice, **V1 should still assume poll or long-poll**:
+
+- external `bus-send` writes to SQLite directly
+- a running stdio MCP child process cannot be woken by that external process
+- `bus_wait` is the reliable wakeup primitive today
+
+## Storage / retention
+
+- DB path: `~/.claude/bus/bus.db`
+- Retention: last `KB_BUS_RETENTION_MESSAGES` per channel (default `200`)
+- Poll interval for `bus_wait`: `KB_BUS_POLL_MS` (default `250`)
+
+## Scope
+
+V1 is intentionally:
+
+- local only
+- append only
+- opaque markdown message bodies
+- no auth beyond local machine trust
+- no cross-machine delivery

--- a/docs/message-bus.md
+++ b/docs/message-bus.md
@@ -45,11 +45,16 @@ Use the returned `next_since` as the next cursor.
 
 `bus://ticket:PF-1884` returns the latest messages for that channel as JSON.
 
-If your MCP host supports resource subscriptions, you can subscribe to that URI. In practice, **V1 should still assume poll or long-poll**:
+If your MCP host supports resource subscriptions, you can subscribe to that URI.
 
-- external `bus-send` writes to SQLite directly
-- a running stdio MCP child process cannot be woken by that external process
-- `bus_wait` is the reliable wakeup primitive today
+The stdio server now emits `notifications/resources/updated` for `bus://<channel>` when:
+
+- a message is sent through the same MCP process, and
+- the local bus SQLite files change due to external CLI writers
+
+That means subscribed hosts can get **best-effort local push** instead of relying only on `bus_wait`.
+
+Still keep `bus_wait` as fallback because client support varies and some hosts may not subscribe to resources automatically.
 
 ## Storage / retention
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "zod": "^4.3.6"
       },
       "bin": {
+        "bus-inbox": "bin/bus-inbox.js",
+        "bus-send": "bin/bus-send.js",
+        "bus-wait": "bin/bus-wait.js",
         "kb": "bin/kb.js"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Portable knowledge base with web dashboard and MCP server for AI tools",
   "type": "module",
   "bin": {
-    "kb": "./bin/kb.js"
+    "kb": "./bin/kb.js",
+    "bus-send": "./bin/bus-send.js",
+    "bus-inbox": "./bin/bus-inbox.js",
+    "bus-wait": "./bin/bus-wait.js"
   },
   "main": "./src/server.js",
   "files": [

--- a/src/bus/cli.js
+++ b/src/bus/cli.js
@@ -1,0 +1,72 @@
+import { getBusInbox, sendBusMessage, waitForBusInbox } from './service.js';
+
+function readFlag(args, name, fallback = undefined) {
+  const index = args.findIndex(arg => arg === name || arg.startsWith(`${name}=`));
+  if (index === -1) return fallback;
+  const arg = args[index];
+  if (arg.includes('=')) return arg.split('=').slice(1).join('=');
+  return args[index + 1] ?? fallback;
+}
+
+function removeFlags(args, names) {
+  const output = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const current = args[i];
+    const flag = names.find(name => current === name || current.startsWith(`${name}=`));
+    if (!flag) {
+      output.push(current);
+      continue;
+    }
+    if (current === flag) i += 1;
+  }
+  return output;
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+export async function runBusSendCli(args) {
+  const sender = readFlag(args, '--sender', process.env.MINO_BUS_SENDER || process.env.USER || 'cli');
+  const kind = readFlag(args, '--kind', 'message');
+  const metadata_json = readFlag(args, '--metadata');
+  const positional = removeFlags(args, ['--sender', '--kind', '--metadata']);
+  const [channel, ...messageParts] = positional;
+  const message = messageParts.join(' ').trim();
+
+  if (!channel || !message) {
+    console.error('Usage: bus-send <channel> <message> [--sender <name>] [--kind <kind>] [--metadata <json>]');
+    process.exit(1);
+  }
+
+  printJson(sendBusMessage({ channel, sender, message, kind, metadata_json }));
+}
+
+export async function runBusInboxCli(args) {
+  const since = readFlag(args, '--since', '0');
+  const limit = readFlag(args, '--limit', '50');
+  const positional = removeFlags(args, ['--since', '--limit']);
+  const [channel] = positional;
+
+  if (!channel) {
+    console.error('Usage: bus-inbox <channel> [--since <cursor>] [--limit <n>]');
+    process.exit(1);
+  }
+
+  printJson(getBusInbox({ channel, since: Number(since), limit: Number(limit) }));
+}
+
+export async function runBusWaitCli(args) {
+  const since = readFlag(args, '--since', '0');
+  const limit = readFlag(args, '--limit', '50');
+  const timeout_ms = readFlag(args, '--timeout-ms', '30000');
+  const positional = removeFlags(args, ['--since', '--limit', '--timeout-ms']);
+  const [channel] = positional;
+
+  if (!channel) {
+    console.error('Usage: bus-wait <channel> [--since <cursor>] [--timeout-ms <ms>] [--limit <n>]');
+    process.exit(1);
+  }
+
+  printJson(await waitForBusInbox({ channel, since: Number(since), timeout_ms: Number(timeout_ms), limit: Number(limit) }));
+}

--- a/src/bus/config.js
+++ b/src/bus/config.js
@@ -1,0 +1,32 @@
+import { mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+
+function readInt(name, fallback) {
+  const value = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function getBusHome() {
+  return process.env.KB_BUS_HOME || join(homedir(), '.claude', 'bus');
+}
+
+export function getBusDbPath() {
+  return process.env.KB_BUS_DB_PATH || join(getBusHome(), 'bus.db');
+}
+
+export function getBusRetentionMessages() {
+  return readInt('KB_BUS_RETENTION_MESSAGES', 200);
+}
+
+export function getBusPollMs() {
+  return readInt('KB_BUS_POLL_MS', 250);
+}
+
+export function getBusResourceLimit() {
+  return readInt('KB_BUS_RESOURCE_LIMIT', 50);
+}
+
+export function ensureBusStorage() {
+  mkdirSync(dirname(getBusDbPath()), { recursive: true });
+}

--- a/src/bus/db.js
+++ b/src/bus/db.js
@@ -1,0 +1,46 @@
+import Database from 'better-sqlite3';
+import { ensureBusStorage, getBusDbPath } from './config.js';
+
+let db = null;
+let dbPath = null;
+
+function initSchema(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS bus_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      channel TEXT NOT NULL,
+      sender TEXT NOT NULL,
+      kind TEXT NOT NULL DEFAULT 'message',
+      body TEXT NOT NULL,
+      metadata_json TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_bus_messages_channel_id
+      ON bus_messages(channel, id);
+
+    CREATE INDEX IF NOT EXISTS idx_bus_messages_created_at
+      ON bus_messages(created_at);
+  `);
+}
+
+export function getBusDb() {
+  const nextPath = getBusDbPath();
+  if (!db || dbPath !== nextPath) {
+    closeBusDb();
+    ensureBusStorage();
+    db = new Database(nextPath);
+    db.pragma('journal_mode = WAL');
+    initSchema(db);
+    dbPath = nextPath;
+  }
+  return db;
+}
+
+export function closeBusDb() {
+  if (db) {
+    db.close();
+    db = null;
+    dbPath = null;
+  }
+}

--- a/src/bus/notifier.js
+++ b/src/bus/notifier.js
@@ -1,0 +1,77 @@
+import { existsSync, watch } from 'fs';
+import { dirname, basename } from 'path';
+import { getBusDbPath } from './config.js';
+import { listBusChannels, onBusMessage } from './service.js';
+
+function toStateMap(channels) {
+  return new Map(channels.map(channel => [channel.channel, Number(channel.latest_id) || 0]));
+}
+
+export function diffBusChannelUris(previous, next) {
+  const uris = [];
+  for (const [channel, latestId] of next.entries()) {
+    if (previous.get(channel) !== latestId) {
+      uris.push(`bus://${channel}`);
+    }
+  }
+  return uris;
+}
+
+function debounce(fn, delayMs) {
+  let timer = null;
+  return () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      fn().catch?.(() => {});
+    }, delayMs);
+    timer.unref?.();
+  };
+}
+
+async function sendResourceUpdated(mcpServer, uri) {
+  if (!mcpServer.isConnected()) return;
+  await mcpServer.server.sendResourceUpdated({ uri });
+}
+
+export function startBusPushNotifier(mcpServer) {
+  let previous = toStateMap(listBusChannels(500));
+  const dbPath = getBusDbPath();
+  const watchedDir = dirname(dbPath);
+  const watchedNames = new Set([
+    basename(dbPath),
+    `${basename(dbPath)}-wal`,
+    `${basename(dbPath)}-shm`,
+  ]);
+
+  const flush = async () => {
+    const next = toStateMap(listBusChannels(500));
+    const changedUris = diffBusChannelUris(previous, next);
+    previous = next;
+    await Promise.all(changedUris.map(uri => sendResourceUpdated(mcpServer, uri)));
+  };
+
+  const flushSoon = debounce(flush, 25);
+  const stopLocalSubscription = onBusMessage(({ channel }) => {
+    previous.set(channel, Number(previous.get(channel) || 0) + 1);
+    sendResourceUpdated(mcpServer, `bus://${channel}`).catch(() => {});
+  });
+
+  let watcher = null;
+  if (existsSync(watchedDir)) {
+    try {
+      watcher = watch(watchedDir, (_eventType, filename) => {
+        if (!filename || watchedNames.has(String(filename))) {
+          flushSoon();
+        }
+      });
+    } catch {
+      watcher = null;
+    }
+  }
+
+  return () => {
+    stopLocalSubscription();
+    watcher?.close();
+  };
+}

--- a/src/bus/resources.js
+++ b/src/bus/resources.js
@@ -1,0 +1,31 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getBusResourceLimit } from './config.js';
+import { listBusChannels, readBusChannel } from './service.js';
+
+export function registerBusResources(server) {
+  server.resource(
+    'bus-channel',
+    new ResourceTemplate('bus://{channel}', {
+      list: async () => ({
+        resources: listBusChannels().map(channel => ({
+          uri: `bus://${channel.channel}`,
+          name: `bus:${channel.channel}`,
+          mimeType: 'application/json',
+          description: `${channel.message_count} message(s), latest id ${channel.latest_id}`,
+        })),
+      }),
+    }),
+    {
+      title: 'Message bus channel',
+      description: 'Read the latest messages for a local agent-to-agent bus channel.',
+      mimeType: 'application/json',
+    },
+    async (_uri, variables) => ({
+      contents: [{
+        uri: `bus://${variables.channel}`,
+        mimeType: 'application/json',
+        text: JSON.stringify(readBusChannel(variables.channel, getBusResourceLimit()), null, 2),
+      }],
+    }),
+  );
+}

--- a/src/bus/service.js
+++ b/src/bus/service.js
@@ -1,6 +1,8 @@
 import { getBusDb } from './db.js';
 import { getBusPollMs, getBusResourceLimit, getBusRetentionMessages } from './config.js';
 
+const busListeners = new Set();
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -40,6 +42,17 @@ function normalizeSince(since) {
   return Math.floor(value);
 }
 
+function emitBusMessage(message) {
+  for (const listener of busListeners) {
+    listener(message);
+  }
+}
+
+export function onBusMessage(listener) {
+  busListeners.add(listener);
+  return () => busListeners.delete(listener);
+}
+
 export function sendBusMessage({ channel, sender, message, kind = 'message', metadata_json }) {
   const db = getBusDb();
   const cleanChannel = requireText(channel, 'channel');
@@ -54,7 +67,9 @@ export function sendBusMessage({ channel, sender, message, kind = 'message', met
   `).run(cleanChannel, cleanSender, cleanKind, cleanMessage, metadata);
 
   pruneChannel(cleanChannel);
-  return getMessageById(result.lastInsertRowid);
+  const created = getMessageById(result.lastInsertRowid);
+  emitBusMessage(created);
+  return created;
 }
 
 function pruneChannel(channel) {

--- a/src/bus/service.js
+++ b/src/bus/service.js
@@ -1,0 +1,166 @@
+import { getBusDb } from './db.js';
+import { getBusPollMs, getBusResourceLimit, getBusRetentionMessages } from './config.js';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function parseMetadata(metadataJson) {
+  if (!metadataJson) return null;
+  return JSON.parse(metadataJson);
+}
+
+function mapMessage(row) {
+  return {
+    id: row.id,
+    channel: row.channel,
+    sender: row.sender,
+    kind: row.kind,
+    body: row.body,
+    metadata: parseMetadata(row.metadata_json),
+    created_at: row.created_at,
+  };
+}
+
+function requireText(value, name) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) throw new Error(`${name} is required`);
+  return trimmed;
+}
+
+function clampLimit(limit, fallback = 50, max = 500) {
+  const value = Number(limit);
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(Math.floor(value), max);
+}
+
+function normalizeSince(since) {
+  const value = Number(since);
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return Math.floor(value);
+}
+
+export function sendBusMessage({ channel, sender, message, kind = 'message', metadata_json }) {
+  const db = getBusDb();
+  const cleanChannel = requireText(channel, 'channel');
+  const cleanSender = requireText(sender, 'sender');
+  const cleanMessage = requireText(message, 'message');
+  const cleanKind = requireText(kind, 'kind');
+  const metadata = metadata_json ? JSON.stringify(JSON.parse(metadata_json)) : null;
+
+  const result = db.prepare(`
+    INSERT INTO bus_messages (channel, sender, kind, body, metadata_json)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(cleanChannel, cleanSender, cleanKind, cleanMessage, metadata);
+
+  pruneChannel(cleanChannel);
+  return getMessageById(result.lastInsertRowid);
+}
+
+function pruneChannel(channel) {
+  const keep = getBusRetentionMessages();
+  const db = getBusDb();
+  db.prepare(`
+    DELETE FROM bus_messages
+    WHERE channel = ?
+      AND id NOT IN (
+        SELECT id FROM bus_messages
+        WHERE channel = ?
+        ORDER BY id DESC
+        LIMIT ?
+      )
+  `).run(channel, channel, keep);
+}
+
+export function getMessageById(id) {
+  const row = getBusDb().prepare(`
+    SELECT id, channel, sender, kind, body, metadata_json, created_at
+    FROM bus_messages
+    WHERE id = ?
+  `).get(id);
+  return row ? mapMessage(row) : null;
+}
+
+export function getBusInbox({ channel, since = 0, limit = 50 }) {
+  const cleanChannel = requireText(channel, 'channel');
+  const cursor = normalizeSince(since);
+  const pageSize = clampLimit(limit);
+  const db = getBusDb();
+
+  const rows = db.prepare(`
+    SELECT id, channel, sender, kind, body, metadata_json, created_at
+    FROM bus_messages
+    WHERE channel = ? AND id > ?
+    ORDER BY id ASC
+    LIMIT ?
+  `).all(cleanChannel, cursor, pageSize);
+
+  const messages = rows.map(mapMessage);
+  const latest = db.prepare(`
+    SELECT MAX(id) AS latest_id
+    FROM bus_messages
+    WHERE channel = ?
+  `).get(cleanChannel);
+
+  return {
+    channel: cleanChannel,
+    messages,
+    count: messages.length,
+    next_since: messages.at(-1)?.id ?? cursor,
+    latest_id: latest?.latest_id ?? cursor,
+  };
+}
+
+export async function waitForBusInbox({ channel, since = 0, timeout_ms = 30000, limit = 50 }) {
+  const cleanChannel = requireText(channel, 'channel');
+  const cursor = normalizeSince(since);
+  const timeout = clampLimit(timeout_ms, 30000, 300000);
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() <= deadline) {
+    const inbox = getBusInbox({ channel: cleanChannel, since: cursor, limit });
+    if (inbox.count > 0) {
+      return { ...inbox, timed_out: false };
+    }
+    await sleep(getBusPollMs());
+  }
+
+  const latest = getBusInbox({ channel: cleanChannel, since: cursor, limit: 1 });
+  return {
+    channel: cleanChannel,
+    messages: [],
+    count: 0,
+    next_since: cursor,
+    latest_id: latest.latest_id,
+    timed_out: true,
+  };
+}
+
+export function readBusChannel(channel, limit = getBusResourceLimit()) {
+  const cleanChannel = requireText(channel, 'channel');
+  const db = getBusDb();
+  const rows = db.prepare(`
+    SELECT id, channel, sender, kind, body, metadata_json, created_at
+    FROM bus_messages
+    WHERE channel = ?
+    ORDER BY id DESC
+    LIMIT ?
+  `).all(cleanChannel, clampLimit(limit, getBusResourceLimit()));
+
+  const messages = rows.reverse().map(mapMessage);
+  return {
+    channel: cleanChannel,
+    messages,
+    latest_id: messages.at(-1)?.id ?? 0,
+  };
+}
+
+export function listBusChannels(limit = 100) {
+  return getBusDb().prepare(`
+    SELECT channel, MAX(id) AS latest_id, COUNT(*) AS message_count
+    FROM bus_messages
+    GROUP BY channel
+    ORDER BY latest_id DESC
+    LIMIT ?
+  `).all(clampLimit(limit, 100, 500));
+}

--- a/src/bus/tools.js
+++ b/src/bus/tools.js
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import { getBusInbox, sendBusMessage, waitForBusInbox } from './service.js';
+
+function ok(payload) {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+function fail(error) {
+  return { content: [{ type: 'text', text: `Error: ${error.message}` }], isError: true };
+}
+
+export function getBusToolDefinitions() {
+  return [
+    {
+      name: 'bus_send',
+      description: 'Send an append-only markdown message to a local cross-agent channel. Use this for Codex↔Claude↔Gemini handoffs, status updates, and task completion reports.',
+      schema: {
+        channel: z.string().describe('Free-form channel ID (e.g. ticket:PF-1884, session:1234, swarm:frontend)'),
+        sender: z.string().describe('Sender label (e.g. codex, claude, gemini, deploy-watcher)'),
+        message: z.string().describe('Markdown message body'),
+        kind: z.string().optional().default('message').describe('Message kind (e.g. message, result, status, error, handoff)'),
+        metadata_json: z.string().optional().describe('Optional JSON metadata string'),
+      },
+      handler: async ({ channel, sender, message, kind, metadata_json }) => {
+        try {
+          return ok(sendBusMessage({ channel, sender, message, kind, metadata_json }));
+        } catch (error) {
+          return fail(error);
+        }
+      },
+    },
+
+    {
+      name: 'bus_inbox',
+      description: 'Read messages from a local cross-agent channel after a cursor. Use the returned next_since as the next cursor.',
+      schema: {
+        channel: z.string().describe('Channel ID'),
+        since: z.number().optional().default(0).describe('Return only messages with id greater than this cursor'),
+        limit: z.number().optional().default(50).describe('Maximum number of messages to return'),
+      },
+      handler: async ({ channel, since, limit }) => {
+        try {
+          return ok(getBusInbox({ channel, since, limit }));
+        } catch (error) {
+          return fail(error);
+        }
+      },
+    },
+
+    {
+      name: 'bus_wait',
+      description: 'Long-poll a local cross-agent channel until a new message arrives or timeout elapses. Use this when the host cannot auto-wake on MCP resource updates.',
+      schema: {
+        channel: z.string().describe('Channel ID'),
+        since: z.number().optional().default(0).describe('Wait for messages newer than this cursor'),
+        timeout_ms: z.number().optional().default(30000).describe('Maximum wait time in milliseconds (max 300000)'),
+        limit: z.number().optional().default(50).describe('Maximum number of messages to return'),
+      },
+      handler: async ({ channel, since, timeout_ms, limit }) => {
+        try {
+          return ok(await waitForBusInbox({ channel, since, timeout_ms, limit }));
+        } catch (error) {
+          return fail(error);
+        }
+      },
+    },
+  ];
+}

--- a/src/cli/mcp-register.js
+++ b/src/cli/mcp-register.js
@@ -1,0 +1,60 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+export const SUPPORTED_AGENTS = ['claude', 'codex', 'gemini'];
+export const KB_MCP_SERVER_NAME = 'knowledge-base';
+export const KB_MCP_SERVER_CONFIG = {
+  command: 'kb',
+  args: ['mcp'],
+};
+
+function readJson(path) {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+export function getAgentConfigPath(agent, homeDir = homedir()) {
+  if (agent === 'claude') return join(homeDir, '.claude.json');
+  if (agent === 'codex') return join(homeDir, '.codex', 'mcp.json');
+  if (agent === 'gemini') return join(homeDir, '.gemini', 'mcp.json');
+  throw new Error(`Unsupported agent: ${agent}`);
+}
+
+export function parseRegisterArgs(args = []) {
+  const flag = args.find(arg => arg.startsWith('--agents='));
+  if (!flag) return [...SUPPORTED_AGENTS];
+
+  const agents = flag
+    .split('=')
+    .slice(1)
+    .join('=')
+    .split(',')
+    .map(agent => agent.trim().toLowerCase())
+    .filter(Boolean);
+
+  const invalid = agents.filter(agent => !SUPPORTED_AGENTS.includes(agent));
+  if (invalid.length > 0) {
+    throw new Error(`Unsupported agent(s): ${invalid.join(', ')}. Supported: ${SUPPORTED_AGENTS.join(', ')}`);
+  }
+  if (agents.length === 0) {
+    throw new Error('No agents provided. Example: kb register --agents=claude,codex');
+  }
+  return [...new Set(agents)];
+}
+
+export function registerAgents(agents, homeDir = homedir()) {
+  return agents.map(agent => {
+    const path = getAgentConfigPath(agent, homeDir);
+    mkdirSync(join(path, '..'), { recursive: true });
+    const config = readJson(path);
+    if (!config.mcpServers) config.mcpServers = {};
+    config.mcpServers[KB_MCP_SERVER_NAME] = KB_MCP_SERVER_CONFIG;
+    writeFileSync(path, JSON.stringify(config, null, 2));
+    return { agent, path };
+  });
+}

--- a/src/cli/mcp-register.js
+++ b/src/cli/mcp-register.js
@@ -1,12 +1,14 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 
 export const SUPPORTED_AGENTS = ['claude', 'codex', 'gemini'];
 export const KB_MCP_SERVER_NAME = 'knowledge-base';
+export const KB_ENTRYPOINT_PATH = fileURLToPath(new URL('../../bin/kb.js', import.meta.url));
 export const KB_MCP_SERVER_CONFIG = {
-  command: 'kb',
-  args: ['mcp'],
+  command: process.execPath,
+  args: [KB_ENTRYPOINT_PATH, 'mcp'],
 };
 
 function readJson(path) {

--- a/src/cli/register.js
+++ b/src/cli/register.js
@@ -1,24 +1,16 @@
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
+import { parseRegisterArgs, registerAgents } from './mcp-register.js';
 
-export function register() {
-  const claudeJsonPath = join(homedir(), '.claude.json');
+export function register(args = []) {
+  const agents = parseRegisterArgs(args);
+  const results = registerAgents(agents);
 
-  let config = {};
-  if (existsSync(claudeJsonPath)) {
-    config = JSON.parse(readFileSync(claudeJsonPath, 'utf-8'));
+  console.log('MCP server registered for:');
+  for (const result of results) {
+    console.log(`- ${result.agent}: ${result.path}`);
   }
-
-  if (!config.mcpServers) config.mcpServers = {};
-
-  config.mcpServers['knowledge-base'] = {
-    command: 'kb',
-    args: ['mcp'],
-  };
-
-  writeFileSync(claudeJsonPath, JSON.stringify(config, null, 2));
-  console.log('MCP server registered in ~/.claude.json');
-  console.log('Restart Claude Code to activate the knowledge-base tools.');
-  console.log('Tools available: kb_search, kb_list, kb_read, kb_ingest');
+  console.log('');
+  console.log('Restart these local agent sessions to activate the updated knowledge-base tools.');
+  console.log('Core tools: kb_search, kb_list, kb_read, kb_ingest, ...');
+  console.log('Local-only bus tools: bus_send, bus_inbox, bus_wait');
+  console.log('Long-lived sessions that cannot restart can still use the CLI fallback: bus-send / bus-inbox / bus-wait');
 }

--- a/src/cli/setup.js
+++ b/src/cli/setup.js
@@ -5,6 +5,7 @@ import { homedir, platform, release, type as osType } from 'os';
 import { join, resolve } from 'path';
 import { execFileSync } from 'child_process';
 import { KB_DIR, ENV_PATH } from '../paths.js';
+import { registerAgents } from './mcp-register.js';
 
 const HOME = homedir();
 
@@ -253,54 +254,10 @@ volumes:
   return composePath;
 }
 
-// ---------------------------------------------------------------------------
-// MCP registration per agent
-// ---------------------------------------------------------------------------
-
-function registerMcpClaude() {
-  const claudeJsonPath = join(HOME, '.claude.json');
-  let config = {};
-  if (existsSync(claudeJsonPath)) {
-    try { config = JSON.parse(readFileSync(claudeJsonPath, 'utf-8')); } catch { config = {}; }
-  }
-  if (!config.mcpServers) config.mcpServers = {};
-  config.mcpServers['knowledge-base'] = { command: 'kb', args: ['mcp'] };
-  writeFileSync(claudeJsonPath, JSON.stringify(config, null, 2));
-  return claudeJsonPath;
-}
-
-function registerMcpCodex() {
-  const dir = join(HOME, '.codex');
-  mkdirSync(dir, { recursive: true });
-  const mcpPath = join(dir, 'mcp.json');
-  let config = {};
-  if (existsSync(mcpPath)) {
-    try { config = JSON.parse(readFileSync(mcpPath, 'utf-8')); } catch { config = {}; }
-  }
-  if (!config.mcpServers) config.mcpServers = {};
-  config.mcpServers['knowledge-base'] = { command: 'kb', args: ['mcp'] };
-  writeFileSync(mcpPath, JSON.stringify(config, null, 2));
-  return mcpPath;
-}
-
-function registerMcpGemini() {
-  const dir = join(HOME, '.gemini');
-  mkdirSync(dir, { recursive: true });
-  const mcpPath = join(dir, 'mcp.json');
-  let config = {};
-  if (existsSync(mcpPath)) {
-    try { config = JSON.parse(readFileSync(mcpPath, 'utf-8')); } catch { config = {}; }
-  }
-  if (!config.mcpServers) config.mcpServers = {};
-  config.mcpServers['knowledge-base'] = { command: 'kb', args: ['mcp'] };
-  writeFileSync(mcpPath, JSON.stringify(config, null, 2));
-  return mcpPath;
-}
-
 const MCP_REGISTRARS = {
-  claude: registerMcpClaude,
-  codex: registerMcpCodex,
-  gemini: registerMcpGemini,
+  claude: () => registerAgents(['claude'], HOME)[0].path,
+  codex: () => registerAgents(['codex'], HOME)[0].path,
+  gemini: () => registerAgents(['gemini'], HOME)[0].path,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { registerBusResources } from './bus/resources.js';
 import { getToolDefinitions } from './tools.js';
 
 export async function start() {
@@ -12,6 +13,7 @@ export async function start() {
   for (const tool of getToolDefinitions()) {
     server.tool(tool.name, tool.description, tool.schema, tool.handler);
   }
+  registerBusResources(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { startBusPushNotifier } from './bus/notifier.js';
 import { registerBusResources } from './bus/resources.js';
 import { getToolDefinitions } from './tools.js';
 
@@ -17,6 +18,7 @@ export async function start() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  startBusPushNotifier(server);
 }
 
 // Allow direct execution

--- a/src/tools.js
+++ b/src/tools.js
@@ -12,6 +12,7 @@ import { formatYamlTags } from './utils/frontmatter.js';
 import { getRecentNotes, generateSynthesisPrompt } from './synthesis/weekly-review.js';
 import { processNewClippings } from './classify/processor.js';
 import { reviewDestructiveAction } from './safety/review.js';
+import { getBusToolDefinitions } from './bus/tools.js';
 
 const ADMIN_ONLY_TOOLS = new Set([
   'kb_classify',
@@ -19,10 +20,14 @@ const ADMIN_ONLY_TOOLS = new Set([
   'kb_synthesize',
   'kb_safety_check',
   'kb_capture_youtube',
+  'bus_send',
+  'bus_inbox',
+  'bus_wait',
 ]);
 
 export function getToolDefinitions() {
   return [
+    ...getBusToolDefinitions(),
     {
       name: 'kb_search',
       description: 'Search the knowledge base using full-text search. Returns ranked results with highlighted snippets.',

--- a/tests/bus.test.js
+++ b/tests/bus.test.js
@@ -6,7 +6,8 @@ import { join } from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { closeBusDb } from '../src/bus/db.js';
-import { getBusInbox, sendBusMessage, waitForBusInbox } from '../src/bus/service.js';
+import { getBusInbox, onBusMessage, sendBusMessage, waitForBusInbox } from '../src/bus/service.js';
+import { diffBusChannelUris } from '../src/bus/notifier.js';
 
 const execFileAsync = promisify(execFile);
 const tempDirs = [];
@@ -106,5 +107,33 @@ describe('message bus service', () => {
     assert.strictEqual(inbox.count, 1);
     assert.strictEqual(inbox.messages[0].sender, 'codex');
     assert.strictEqual(inbox.messages[0].kind, 'result');
+  });
+
+  it('emits in-process message notifications', async () => {
+    makeBusHome();
+
+    const seen = [];
+    const stop = onBusMessage(message => seen.push(message));
+    try {
+      sendBusMessage({ channel: 'ticket:PF-1884', sender: 'codex:test', message: 'hello' });
+    } finally {
+      stop();
+    }
+
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].channel, 'ticket:PF-1884');
+    assert.strictEqual(seen[0].body, 'hello');
+  });
+});
+
+describe('bus notifier diffing', () => {
+  it('returns URIs for channels whose latest id changed', () => {
+    const previous = new Map([['ticket:PF-1884', 1], ['session:abc', 2]]);
+    const next = new Map([['ticket:PF-1884', 2], ['session:abc', 2], ['swarm:test', 1]]);
+
+    assert.deepStrictEqual(
+      diffBusChannelUris(previous, next).sort(),
+      ['bus://swarm:test', 'bus://ticket:PF-1884'],
+    );
   });
 });

--- a/tests/bus.test.js
+++ b/tests/bus.test.js
@@ -1,0 +1,110 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { closeBusDb } from '../src/bus/db.js';
+import { getBusInbox, sendBusMessage, waitForBusInbox } from '../src/bus/service.js';
+
+const execFileAsync = promisify(execFile);
+const tempDirs = [];
+
+function makeBusHome() {
+  const dir = mkdtempSync(join(tmpdir(), 'kb-bus-test-'));
+  tempDirs.push(dir);
+  process.env.KB_BUS_HOME = dir;
+  delete process.env.KB_BUS_DB_PATH;
+  closeBusDb();
+  return dir;
+}
+
+afterEach(() => {
+  closeBusDb();
+  delete process.env.KB_BUS_HOME;
+  delete process.env.KB_BUS_DB_PATH;
+  delete process.env.KB_BUS_RETENTION_MESSAGES;
+  while (tempDirs.length) rmSync(tempDirs.pop(), { recursive: true, force: true });
+});
+
+describe('message bus service', () => {
+  it('sends and reads messages using cursor semantics', () => {
+    makeBusHome();
+
+    const first = sendBusMessage({
+      channel: 'ticket:PF-1884',
+      sender: 'codex',
+      message: 'done',
+      kind: 'result',
+      metadata_json: JSON.stringify({ model: 'gpt-5.4' }),
+    });
+    sendBusMessage({
+      channel: 'ticket:PF-1884',
+      sender: 'claude',
+      message: 'ack',
+    });
+
+    const inbox = getBusInbox({ channel: 'ticket:PF-1884', since: 0 });
+    assert.strictEqual(inbox.count, 2);
+    assert.strictEqual(inbox.messages[0].id, first.id);
+    assert.deepStrictEqual(inbox.messages[0].metadata, { model: 'gpt-5.4' });
+
+    const next = getBusInbox({ channel: 'ticket:PF-1884', since: first.id });
+    assert.strictEqual(next.count, 1);
+    assert.strictEqual(next.messages[0].body, 'ack');
+  });
+
+  it('waits for messages and times out cleanly', async () => {
+    makeBusHome();
+
+    const pending = waitForBusInbox({ channel: 'session:test', since: 0, timeout_ms: 1000 });
+    setTimeout(() => {
+      sendBusMessage({ channel: 'session:test', sender: 'watcher', message: 'ready' });
+    }, 50);
+
+    const found = await pending;
+    assert.strictEqual(found.timed_out, false);
+    assert.strictEqual(found.count, 1);
+    assert.strictEqual(found.messages[0].body, 'ready');
+
+    const timedOut = await waitForBusInbox({ channel: 'session:test', since: found.next_since, timeout_ms: 50 });
+    assert.strictEqual(timedOut.timed_out, true);
+    assert.strictEqual(timedOut.count, 0);
+  });
+
+  it('retains only the latest N messages per channel', () => {
+    makeBusHome();
+    process.env.KB_BUS_RETENTION_MESSAGES = '2';
+
+    sendBusMessage({ channel: 'swarm:test', sender: 'a', message: 'one' });
+    sendBusMessage({ channel: 'swarm:test', sender: 'b', message: 'two' });
+    sendBusMessage({ channel: 'swarm:test', sender: 'c', message: 'three' });
+
+    const inbox = getBusInbox({ channel: 'swarm:test', since: 0, limit: 10 });
+    assert.strictEqual(inbox.count, 2);
+    assert.deepStrictEqual(inbox.messages.map(msg => msg.body), ['two', 'three']);
+  });
+
+  it('CLI shim writes messages without MCP', async () => {
+    const home = makeBusHome();
+
+    await execFileAsync('node', [
+      'bin/bus-send.js',
+      'ticket:PF-1884',
+      'report ready',
+      '--sender',
+      'codex',
+      '--kind',
+      'result',
+    ], {
+      cwd: process.cwd(),
+      env: { ...process.env, KB_BUS_HOME: home },
+    });
+
+    const inbox = getBusInbox({ channel: 'ticket:PF-1884', since: 0 });
+    assert.strictEqual(inbox.count, 1);
+    assert.strictEqual(inbox.messages[0].sender, 'codex');
+    assert.strictEqual(inbox.messages[0].kind, 'result');
+  });
+});

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -3,7 +3,12 @@ import assert from 'node:assert';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { getAgentConfigPath, parseRegisterArgs, registerAgents } from '../src/cli/mcp-register.js';
+import {
+  getAgentConfigPath,
+  KB_ENTRYPOINT_PATH,
+  parseRegisterArgs,
+  registerAgents,
+} from '../src/cli/mcp-register.js';
 
 const tempDirs = [];
 
@@ -42,7 +47,13 @@ describe('MCP registration', () => {
     const claudeConfig = JSON.parse(readFileSync(getAgentConfigPath('claude', homeDir), 'utf-8'));
     const codexConfig = JSON.parse(readFileSync(getAgentConfigPath('codex', homeDir), 'utf-8'));
 
-    assert.deepStrictEqual(claudeConfig.mcpServers['knowledge-base'], { command: 'kb', args: ['mcp'] });
-    assert.deepStrictEqual(codexConfig.mcpServers['knowledge-base'], { command: 'kb', args: ['mcp'] });
+    assert.deepStrictEqual(claudeConfig.mcpServers['knowledge-base'], {
+      command: process.execPath,
+      args: [KB_ENTRYPOINT_PATH, 'mcp'],
+    });
+    assert.deepStrictEqual(codexConfig.mcpServers['knowledge-base'], {
+      command: process.execPath,
+      args: [KB_ENTRYPOINT_PATH, 'mcp'],
+    });
   });
 });

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -1,0 +1,48 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getAgentConfigPath, parseRegisterArgs, registerAgents } from '../src/cli/mcp-register.js';
+
+const tempDirs = [];
+
+function makeHome() {
+  const dir = mkdtempSync(join(tmpdir(), 'kb-register-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop(), { recursive: true, force: true });
+});
+
+describe('MCP registration', () => {
+  it('defaults to all supported agents', () => {
+    assert.deepStrictEqual(parseRegisterArgs([]), ['claude', 'codex', 'gemini']);
+  });
+
+  it('parses an explicit agent subset', () => {
+    assert.deepStrictEqual(parseRegisterArgs(['--agents=claude,codex,claude']), ['claude', 'codex']);
+  });
+
+  it('rejects unsupported agents', () => {
+    assert.throws(() => parseRegisterArgs(['--agents=claude,foo']), /Unsupported agent/);
+  });
+
+  it('writes config files for selected agents', () => {
+    const homeDir = makeHome();
+    const results = registerAgents(['claude', 'codex'], homeDir);
+
+    assert.strictEqual(results.length, 2);
+    assert.ok(existsSync(getAgentConfigPath('claude', homeDir)));
+    assert.ok(existsSync(getAgentConfigPath('codex', homeDir)));
+    assert.ok(!existsSync(getAgentConfigPath('gemini', homeDir)));
+
+    const claudeConfig = JSON.parse(readFileSync(getAgentConfigPath('claude', homeDir), 'utf-8'));
+    const codexConfig = JSON.parse(readFileSync(getAgentConfigPath('codex', homeDir), 'utf-8'));
+
+    assert.deepStrictEqual(claudeConfig.mcpServers['knowledge-base'], { command: 'kb', args: ['mcp'] });
+    assert.deepStrictEqual(codexConfig.mcpServers['knowledge-base'], { command: 'kb', args: ['mcp'] });
+  });
+});

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -6,7 +6,7 @@ describe('tools', () => {
   it('exports an array of tool definitions', () => {
     const tools = getToolDefinitions();
     assert.ok(Array.isArray(tools));
-    assert.ok(tools.length >= 16);
+    assert.ok(tools.length >= 19);
   });
 
   it('each tool has name, description, schema, handler', () => {
@@ -23,6 +23,7 @@ describe('tools', () => {
     const tools = getToolDefinitions();
     const names = tools.map(t => t.name);
     const expected = [
+      'bus_send', 'bus_inbox', 'bus_wait',
       'kb_search', 'kb_list', 'kb_read', 'kb_ingest',
       'kb_write', 'kb_vault_status', 'kb_capture_youtube',
       'kb_capture_web', 'kb_capture_session', 'kb_capture_fix',
@@ -42,6 +43,9 @@ describe('tools', () => {
     assert.ok(!names.includes('kb_synthesize'));
     assert.ok(!names.includes('kb_safety_check'));
     assert.ok(!names.includes('kb_capture_youtube'));
+    assert.ok(!names.includes('bus_send'));
+    assert.ok(!names.includes('bus_inbox'));
+    assert.ok(!names.includes('bus_wait'));
     // Should still include read + limited write tools
     assert.ok(names.includes('kb_search'));
     assert.ok(names.includes('kb_ingest'));


### PR DESCRIPTION
## Summary
- add a local-only message bus to the knowledge-base MCP server for cross-model agent coordination
- expose bus MCP tools, resource subscriptions, CLI fallbacks, and local registration updates
- send best-effort push notifications for `bus://<channel>` resource subscribers and fix `kb register` to use an absolute Node entrypoint

## Testing
- `node --test`
- `node --test tests/register.test.js`
